### PR TITLE
Feature/sensitive by default 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ one of:
 | -------------------------- | -------------------------------------| -----------
 | BIND_ADDR                  | :23100                               | The host and port to bind to
 | DATASET_API_URL            | http://localhost:22000               | The host name for the dataset API
-| DATASET_API_SECRET_KEY     | FD0108EA-825D-411C-9B1D-41EF7727F465 | The dataset APi secret key used for authentication
+| DATASET_API_AUTH_TOKEN     | FD0108EA-825D-411C-9B1D-41EF7727F465 | The auth token used for authentication to the dataset API
 | ELASTIC_SEARCH_URL         | http://localhost:9200                | The host name for elasticsearch
 | GRACEFUL_SHUTDOWN_TIMEOUT  | 5s                                   | The graceful shutdown timeout
 | HEALTHCHECK_INTERVAL       | 1m                                   | The time between calling the healthcheck endpoint for check subsystems

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -182,25 +182,25 @@ func TestCreateSearchIndexReturnsOK(t *testing.T) {
 }
 
 func TestFailToCreateSearchIndex(t *testing.T) {
-	Convey("Given a request to create search index but no auth header is set return a status 401 (unauthorised)", t, func() {
+	Convey("Given a request to create search index but no auth header is set return a status 404 (not found)", t, func() {
 		r := httptest.NewRequest("PUT", "http://localhost:23100/search/instances/123/dimensions/aggregate", nil)
 		w := httptest.NewRecorder()
 
 		api := routes(host, secretKey, datasetAPISecretKey, mux.NewRouter(), &mocks.BuildSearch{}, &mocks.DatasetAPI{}, &mocks.Elasticsearch{}, defaultMaxResults)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
-		So(w.Body.String(), ShouldEqual, "No authentication header provided\n")
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldEqual, "Resource not found\n")
 	})
 
-	Convey("Given a request to create search index but the auth header is wrong return a status 401 (unauthorised)", t, func() {
+	Convey("Given a request to create search index but the auth header is wrong return a status 404 (not found)", t, func() {
 		r := httptest.NewRequest("PUT", "http://localhost:23100/search/instances/123/dimensions/aggregate", nil)
 		w := httptest.NewRecorder()
 		r.Header.Add("internal-token", "abcdef")
 
 		api := routes(host, secretKey, datasetAPISecretKey, mux.NewRouter(), &mocks.BuildSearch{}, &mocks.DatasetAPI{}, &mocks.Elasticsearch{}, defaultMaxResults)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
-		So(w.Body.String(), ShouldEqual, "Unauthorised access to API\n")
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldEqual, "Resource not found\n")
 	})
 
 	Convey("Given a request to create search index but unable to connect to kafka broker return a status 500 (internal service error)", t, func() {
@@ -228,25 +228,25 @@ func TestDeleteSearchIndexReturnsOK(t *testing.T) {
 }
 
 func TestFailToDeleteSearchIndex(t *testing.T) {
-	Convey("Given a search index exists but no auth header set return a status 401 (unauthorised)", t, func() {
+	Convey("Given a search index exists but no auth header set return a status 404 (not found)", t, func() {
 		r := httptest.NewRequest("DELETE", "http://localhost:23100/search/instances/123/dimensions/aggregate", nil)
 		w := httptest.NewRecorder()
 
 		api := routes(host, secretKey, datasetAPISecretKey, mux.NewRouter(), &mocks.BuildSearch{}, &mocks.DatasetAPI{}, &mocks.Elasticsearch{}, defaultMaxResults)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
-		So(w.Body.String(), ShouldEqual, "No authentication header provided\n")
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldEqual, "Resource not found\n")
 	})
 
-	Convey("Given a search index exists but auth header is wrong return a status 401 (unauthorised)", t, func() {
+	Convey("Given a search index exists but auth header is wrong return a status 404 (not found)", t, func() {
 		r := httptest.NewRequest("DELETE", "http://localhost:23100/search/instances/123/dimensions/aggregate", nil)
 		w := httptest.NewRecorder()
 		r.Header.Add("internal-token", "abcdef")
 
 		api := routes(host, secretKey, datasetAPISecretKey, mux.NewRouter(), &mocks.BuildSearch{}, &mocks.DatasetAPI{}, &mocks.Elasticsearch{}, defaultMaxResults)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
-		So(w.Body.String(), ShouldEqual, "Unauthorised access to API\n")
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+		So(w.Body.String(), ShouldEqual, "Resource not found\n")
 	})
 
 	Convey("Given a search index exists but unable to connect to elasticsearch cluster return a status 500 (internal service error)", t, func() {

--- a/auth/authentication.go
+++ b/auth/authentication.go
@@ -13,19 +13,22 @@ type Authenticator struct {
 	HeaderName string
 }
 
-const UnauthorisedPublicStatus = http.StatusNotFound
+const (
+	UnauthorisedPublicStatus = http.StatusNotFound
+	UnauthorisedReturnedBody = "Resource not found"
+)
 
 // Check wraps a HTTP handle. If authentication fails an error code is returned else the HTTP handler is called
 func (a *Authenticator) Check(handle func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key := r.Header.Get(a.HeaderName)
 		if key == "" {
-			http.Error(w, "No authentication header provided", UnauthorisedPublicStatus)
+			http.Error(w, UnauthorisedReturnedBody, UnauthorisedPublicStatus)
 			log.Error(errors.New("client missing token"), log.Data{"header": a.HeaderName})
 			return
 		}
 		if key != a.SecretKey {
-			http.Error(w, "Unauthorised access to API", UnauthorisedPublicStatus)
+			http.Error(w, UnauthorisedReturnedBody, UnauthorisedPublicStatus)
 			log.Error(errors.New("unauthorised access to API"), log.Data{"header": a.HeaderName})
 			return
 		}

--- a/auth/authentication.go
+++ b/auth/authentication.go
@@ -13,17 +13,19 @@ type Authenticator struct {
 	HeaderName string
 }
 
+const UnauthorisedPublicStatus = http.StatusNotFound
+
 // Check wraps a HTTP handle. If authentication fails an error code is returned else the HTTP handler is called
 func (a *Authenticator) Check(handle func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key := r.Header.Get(a.HeaderName)
 		if key == "" {
-			http.Error(w, "No authentication header provided", http.StatusUnauthorized)
+			http.Error(w, "No authentication header provided", UnauthorisedPublicStatus)
 			log.Error(errors.New("client missing token"), log.Data{"header": a.HeaderName})
 			return
 		}
 		if key != a.SecretKey {
-			http.Error(w, "Unauthorised access to API", http.StatusUnauthorized)
+			http.Error(w, "Unauthorised access to API", UnauthorisedPublicStatus)
 			log.Error(errors.New("unauthorised access to API"), log.Data{"header": a.HeaderName})
 			return
 		}

--- a/auth/authentication_test.go
+++ b/auth/authentication_test.go
@@ -10,26 +10,26 @@ import (
 
 func TestMiddleWareAuthenticationReturnsForbidden(t *testing.T) {
 	t.Parallel()
-	Convey("When no access token is provide, unauthorised status code is returned", t, func() {
+	Convey("When no access token is provide, not-found status code is returned", t, func() {
 		auth := &Authenticator{"123", "internal-token"}
 		r, err := http.NewRequest("POST", "http://localhost:23100/search/datasets/123/editions/2017/versions/1/dimensions/aggregate", nil)
 		So(err, ShouldBeNil)
 		w := httptest.NewRecorder()
 		auth.Check(mockHTTPHandler).ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
 	})
 }
 
 func TestMiddleWareAuthenticationReturnsUnauthorised(t *testing.T) {
 	t.Parallel()
-	Convey("When a invalid access token is provide, unauthorised status code is returned", t, func() {
+	Convey("When a invalid access token is provide, no-found status code is returned", t, func() {
 		auth := &Authenticator{"123", "internal-token"}
 		r, err := http.NewRequest("POST", "http://localhost:23100/search/datasets/123/editions/2017/versions/1/dimensions/aggregate", nil)
 		r.Header.Set("internal-token", "12")
 		So(err, ShouldBeNil)
 		w := httptest.NewRecorder()
 		auth.Check(mockHTTPHandler).ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusUnauthorized)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
 	})
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	BindAddr                  string        `envconfig:"BIND_ADDR"                  json:"-"`
 	Brokers                   []string      `envconfig:"KAFKA_ADDR"                 json:"-"`
 	DatasetAPIURL             string        `envconfig:"DATASET_API_URL"`
-	DatasetAPISecretKey       string        `envconfig:"DATASET_API_SECRET_KEY"     json:"-"`
+	DatasetAPISecretKey       string        `envconfig:"DATASET_API_AUTH_TOKEN"     json:"-"`
 	ElasticSearchAPIURL       string        `envconfig:"ELASTIC_SEARCH_URL"         json:"-"`
 	GracefulShutdownTimeout   time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval       time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -89,8 +89,6 @@ paths:
             $ref: '#/definitions/Dimension_Options'
         400:
           $ref: '#/responses/InvalidRequestError'
-        401:
-          $ref: '#/responses/UnauthorisedError'
         404:
           $ref: '#/responses/NotFoundError'
         500:
@@ -107,8 +105,8 @@ paths:
       responses:
         200:
           description: "The index was created"
-        401:
-          $ref: '#/responses/UnauthorisedError'
+        404:
+          $ref: '#/responses/NotFoundError'
         500:
           $ref: '#/responses/InternalError'
     delete:
@@ -122,8 +120,6 @@ paths:
       responses:
         200:
           description: "The index was removed"
-        401:
-          $ref: '#/responses/UnauthorisedError'
         404:
           description: "The index was not found"
         500:
@@ -134,9 +130,7 @@ responses:
   InternalError:
     description: "Failed to process the request due to an internal error."
   NotFoundError:
-    description: "Dimension not found."
-  UnauthorisedError:
-    description: "The token provided is unauthorised to carry out this operation."
+    description: "Dimension or option not found."
 definitions:
   Dimension_Options:
     description: "The resulting resource of the completed search against a dimension hierarchy."
@@ -165,7 +159,7 @@ definitions:
       code:
         type: string
         description: "The code for this dimension option."
-      dimension_option_url: 
+      dimension_option_url:
         type: string
         description: "The id of a collection of datasets that a dataset is associated to."
       has_data:


### PR DESCRIPTION
### What

change 401 unauthenticated requests to return 404

### How to review

run the tests, check the docs

### Who can review

you, not me

### Note

env var `DATASET_API_SECRET_KEY` **no longer used**
use more standard `DATASET_API_AUTH_TOKEN`

### Cross-referenced PRs

merge with

- https://github.com/ONSdigital/dp-ci/pull/295
- https://github.com/ONSdigital/dp-api-tests/pull/43
