### PR TITLE
Remove test for default configuration for `HasPrivateEndpoints`

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,6 @@ func TestSpec(t *testing.T) {
 				So(cfg.DatasetAPISecretKey, ShouldEqual, "FD0108EA-825D-411C-9B1D-41EF7727F465")
 				So(cfg.ElasticSearchAPIURL, ShouldEqual, "http://localhost:9200")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
-				So(cfg.HasPrivateEndpoints, ShouldEqual, false)
 				So(cfg.HealthCheckInterval, ShouldEqual, 60*time.Second)
 				So(cfg.HealthCheckTimeout, ShouldEqual, 2*time.Second)
 				So(cfg.HierarchyBuiltTopic, ShouldEqual, "hierarchy-built")


### PR DESCRIPTION
### What

This variable is always set to true in Makefile and overides the
default, there seems no value in testing for the default of false as
this is used only in dev environments.

### How to review

Make sure unit tests pass with `make test`

### Who can review

Team B
