### PR TITLE
Set default ports to match dp-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | BIND_ADDR                  | :23100                               | The host and port to bind to
 | DATASET_API_URL            | http://localhost:22000               | The host name for the dataset API
 | DATASET_API_AUTH_TOKEN     | FD0108EA-825D-411C-9B1D-41EF7727F465 | The auth token used for authentication to the dataset API
-| ELASTIC_SEARCH_URL         | http://localhost:9200                | The host name for elasticsearch
+| ELASTIC_SEARCH_URL         | http://localhost:10200               | The host name for elasticsearch
 | ENABLE_PRIVATE_ENDPOINTS   | false                                | Set true ("1","t","true") when private endpoints should be accessible
 | GRACEFUL_SHUTDOWN_TIMEOUT  | 5s                                   | The graceful shutdown timeout
 | HEALTHCHECK_INTERVAL       | 1m                                   | The time between calling the healthcheck endpoint for check subsystems

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ func Get() (*Config, error) {
 		BindAddr:                  ":23100",
 		Brokers:                   []string{"localhost:9092"},
 		DatasetAPIURL:             "http://localhost:22000",
-		ElasticSearchAPIURL:       "http://localhost:9200",
+		ElasticSearchAPIURL:       "http://localhost:10200",
 		GracefulShutdownTimeout:   5 * time.Second,
 		HasPrivateEndpoints:       true,
 		HealthCheckInterval:       1 * time.Minute,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":23100")
 				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092"})
 				So(cfg.DatasetAPIURL, ShouldEqual, "http://localhost:22000")
-				So(cfg.ElasticSearchAPIURL, ShouldEqual, "http://localhost:9200")
+				So(cfg.ElasticSearchAPIURL, ShouldEqual, "http://localhost:10200")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 60*time.Second)
 				So(cfg.HealthCheckTimeout, ShouldEqual, 2*time.Second)


### PR DESCRIPTION
### What

Set default ports to match dp-compose

- going through the getting started guide suggests using dp-compose to start two instances of elastic search. This service uses the default elastic search port, which is not the right port when using dp-compose. To remove friction from the setup process I have set the default to align with dp-compose and the getting started guide.

### How to review

Review changes, considering how you have this setup

### Who can review

Anyone
