### PR TITLE
Increase healthy_deadline in the nomad plan

### DIFF
--- a/dp-search-api.nomad
+++ b/dp-search-api.nomad
@@ -6,7 +6,7 @@ job "dp-search-api" {
   update {
     stagger          = "60s"
     min_healthy_time = "30s"
-    healthy_deadline = "2m"
+    healthy_deadline = "10m"
     max_parallel     = 1
     auto_revert      = true
   }


### PR DESCRIPTION
### What
Increase healthy_deadline in the nomad plan
- the existing value did not give the application enough time to register successful health checks

### How to review
sanity check

### Who can review
Anyone
