### PR TITLE
Lower healthy_dealine to be lower than progress_deadline

### DIFF
--- a/dp-search-api.nomad
+++ b/dp-search-api.nomad
@@ -6,7 +6,7 @@ job "dp-search-api" {
   update {
     stagger          = "60s"
     min_healthy_time = "30s"
-    healthy_deadline = "10m"
+    healthy_deadline = "9m"
     max_parallel     = 1
     auto_revert      = true
   }


### PR DESCRIPTION
### What
Lower healthy_dealine to be lower than progress_deadline
- Healthy deadline must be less than progress deadline
