### PR TITLE
Feature/post elasticsearch index

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,35 +6,32 @@ A Go application microservice to provide query functionality on the ONS Website
 
 ### Getting started
 
-* There are now 2 versions of ElasticSearch being used by this service:
+There are now 2 versions of ElasticSearch being used by this service:
 * 2.4.2 (the old/existing ElasticSearch)
 * 7.10.0 (Site Wide ElasticSearch)
-  
-Version 2.4.2 is used by all endpoints except for the POST /search endpoint, which uses 7.10
 
-* Set up dependencies locally as follows:
+Version 2.4.2 is required by all endpoints except for the POST /search endpoint, which uses 7.10
 
-In dp-compose run `docker-compose up -d` to run both versions of ElasticSearch
-NB. Version 2.4.2 will run on port 9200, version 7.10 will run on port 11200
+Set up dependencies locally as follows:
 
-If using version 2.4.2, there are no more dependencies to set up. Of if using version 7.10 then authorisation for the POST /search endpoint requires running Vault and Zebedee as follows:
+* In dp-compose run `docker-compose up -d` to run both versions of ElasticSearch
+* NB. Version 2.4.2 will run on port 9200, version 7.10 will run on port 11200
+* If using endpoints that require version 2.4.2, there are no more dependencies to set up.
+* NB. What endpoints are available depends on what port the ELASTIC_SEARCH_URL points to. By default, it points to port 9200, so to point to 11200 (if required) run the following:
+* `export ELASTIC_SEARCH_URL="http://localhost:11200"`
+* If using the POST /search endpoint then authorisation for this requires running Vault and Zebedee as follows:
+* In any directory run `vault server -dev` as Zebedee has a dependency on Vault
+* In the zebedee directory run `./run.sh` to run Zebedee
 
-In any directory run `vault server -dev` as Zebedee has a dependency on Vault
-
-In the zebedee directory run `./run.sh` to run Zebedee
-
-For version 7.10 it is also necessary to export the ELASTIC_SEARCH_URL, environment variable, as follows:
-`export ELASTIC_SEARCH_URL="http://localhost:11200"`
-
-* Then in the dp-search-api run `make debug`
+Then run `make debug`
 
 ### Dependencies
 
-For the old/existing ElasticSearch (version 2.4.2):
+For endpoints that require the old/existing ElasticSearch (version 2.4.2):
 * Requires ElasticSearch running on port 9200
 * No further dependencies other than those defined in `go.mod`
 
-For the Site Wide ElasticSearch (version 7.10.0):
+For endpoints that require the Site Wide ElasticSearch (version 7.10.0):
 * Requires ElasticSearch running on port 11200
 * Requires Zebedee running on port 8082
 * No further dependencies other than those defined in `go.mod`
@@ -49,9 +46,12 @@ environment variables, or with a link to a configuration guide.
 | AWS_REGION                  | eu-west-1               | The AWS region to use when signing requests with AWS SDK
 | AWS_SERVICE                 | "es"                    | The aws service that the AWS SDK signing mechanism needs to sign a request
 | BIND_ADDR                   | :23900                  | The host and port to bind to
-| ELASTIC_URL	              | "http://localhost:9200" | Http url of the ElasticSearch server
-| SIGN_ELASTICSEARCH_REQUESTS | false                   | Boolean flag to identify whether elasticsearch requests via elastic API need to be signed if elasticsearch cluster is running in aws
+| ELASTIC_SEARCH_URL	      | "http://localhost:9200" | Http url of the ElasticSearch server. For Site Wide ElasticSearch this needs to be set to "http://localhost:11200".
 | GRACEFUL_SHUTDOWN_TIMEOUT   | 5s                      | The graceful shutdown timeout in seconds (`time.Duration` format)
+| SIGN_ELASTICSEARCH_REQUESTS | false                   | Boolean flag to identify whether elasticsearch requests via elastic API need to be signed if elasticsearch cluster is running in aws
+| HEALTHCHECK_CRITICAL_TIMEOUT| 90s                     | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| HEALTHCHECK_INTERVAL        | 30s                     | Time between self-healthchecks (`time.Duration` format)
+| ZEBEDEE_URL                 | http://localhost:8082   | The URL to Zebedee (for authorisation)
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,38 @@ A Go application microservice to provide query functionality on the ONS Website
 
 ### Getting started
 
-* Run `make debug`
+* There are now 2 versions of ElasticSearch being used by this service:
+* 2.4.2 (the old/existing ElasticSearch)
+* 7.10.0 (Site Wide ElasticSearch)
+  
+Version 2.4.2 is used by all endpoints except for the POST /search endpoint, which uses 7.10
+
+* Set up dependencies locally as follows:
+
+In dp-compose run `docker-compose up -d` to run both versions of ElasticSearch
+NB. Version 2.4.2 will run on port 9200, version 7.10 will run on port 11200
+
+If using version 2.4.2, there are no more dependencies to set up. Of if using version 7.10 then authorisation for the POST /search endpoint requires running Vault and Zebedee as follows:
+
+In any directory run `vault server -dev` as Zebedee has a dependency on Vault
+
+In the zebedee directory run `./run.sh` to run Zebedee
+
+For version 7.10 it is also necessary to export the ELASTIC_SEARCH_URL, environment variable, as follows:
+`export ELASTIC_SEARCH_URL="http://localhost:11200"`
+
+* Then in the dp-search-api run `make debug`
 
 ### Dependencies
 
-Clone and set up the following project following the README instructions:
-- [dp-compose](https://github.com/ONSdigital/dp-compose)
+For the old/existing ElasticSearch (version 2.4.2):
+* Requires ElasticSearch running on port 9200
+* No further dependencies other than those defined in `go.mod`
 
-No further dependencies other than those defined in `go.mod`
+For the Site Wide ElasticSearch (version 7.10.0):
+* Requires ElasticSearch running on port 11200
+* Requires Zebedee running on port 8082
+* No further dependencies other than those defined in `go.mod`
 
 ### Configuration
 

--- a/api/api.go
+++ b/api/api.go
@@ -30,6 +30,7 @@ type ElasticSearcher interface {
 	Search(ctx context.Context, index string, docType string, request []byte) ([]byte, error)
 	MultiSearch(ctx context.Context, index string, docType string, request []byte) ([]byte, error)
 	GetStatus(ctx context.Context) ([]byte, error)
+	CreateNewEmptyIndex(ctx context.Context, indexName string) (bool, error)
 }
 
 // QueryBuilder provides methods for the search package
@@ -100,6 +101,8 @@ func NewSearchAPI(router *mux.Router, elasticSearch ElasticSearcher, queryBuilde
 	router.HandleFunc("/search", SearchHandlerFunc(queryBuilder, api.ElasticSearch, api.Transformer)).Methods("GET")
 	router.HandleFunc("/timeseries/{cdid}", TimeseriesLookupHandlerFunc(api.ElasticSearch)).Methods("GET")
 	router.HandleFunc("/data", DataLookupHandlerFunc(api.ElasticSearch)).Methods("GET")
+	router.HandleFunc("/search", CreateSearchIndexHandlerFunc(api.ElasticSearch)).Methods("POST")
+
 	return api
 }
 

--- a/api/search.go
+++ b/api/search.go
@@ -150,8 +150,9 @@ func CreateSearchIndexHandlerFunc(elasticSearchClient ElasticSearcher) http.Hand
 		indexCreated, err := elasticSearchClient.CreateNewEmptyIndex(ctx, indexName)
 		if !indexCreated {
 			if err != nil {
-				http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+				log.Error(ctx, "creating index failed with this error", err)
 			}
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
 			return
 		}
 

--- a/api/search.go
+++ b/api/search.go
@@ -158,9 +158,8 @@ func CreateSearchIndexHandlerFunc(elasticSearchClient ElasticSearcher) http.Hand
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		createIndexResponse := CreateIndexResponse{
-			IndexName: indexName}
-		jsonResponse, _ := json.MarshalIndent(createIndexResponse, "", " ")
+		createIndexResponse := CreateIndexResponse{IndexName: indexName}
+		jsonResponse, _ := json.Marshal(createIndexResponse)
 
 		_, err = w.Write(jsonResponse)
 		if err != nil {

--- a/api/search.go
+++ b/api/search.go
@@ -161,7 +161,6 @@ func CreateSearchIndexHandlerFunc(elasticSearchClient ElasticSearcher) http.Hand
 			IndexName: indexName}
 		jsonResponse, _ := json.MarshalIndent(createIndexResponse, "", " ")
 
-		//_ = ioutil.WriteFile("test.json", file, 0644)
 		_, err = w.Write(jsonResponse)
 		if err != nil {
 			log.Error(ctx, "writing response failed", err)

--- a/api/search.go
+++ b/api/search.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/pkg/errors"
@@ -14,8 +16,8 @@ const defaultContentTypes string = "bulletin," +
 	"article," +
 	"article_download," +
 	"compendium_landing_page," +
-	"dataset_landing_page," +
 	"reference_tables," +
+	"dataset_landing_page," +
 	"static_adhoc," +
 	"static_article," +
 	"static_foi," +
@@ -25,6 +27,12 @@ const defaultContentTypes string = "bulletin," +
 	"static_page," +
 	"static_qmi," +
 	"timeseries"
+
+var serverErrorMessage = "internal server error"
+
+type CreateIndexResponse struct {
+	IndexName string
+}
 
 func paramGet(params url.Values, key, defaultValue string) string {
 	value := params.Get(key)
@@ -131,4 +139,39 @@ func SearchHandlerFunc(queryBuilder QueryBuilder, elasticSearchClient ElasticSea
 		}
 
 	}
+}
+
+func CreateSearchIndexHandlerFunc(elasticSearchClient ElasticSearcher) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		indexName := createIndexName("ons")
+		fmt.Printf("Index created: %s\n", indexName)
+
+		indexCreated, err := elasticSearchClient.CreateNewEmptyIndex(ctx, indexName)
+		if !indexCreated {
+			if err != nil {
+				http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+			}
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		createIndexResponse := CreateIndexResponse{
+			IndexName: indexName}
+		jsonResponse, _ := json.MarshalIndent(createIndexResponse, "", " ")
+
+		//_ = ioutil.WriteFile("test.json", file, 0644)
+		_, err = w.Write(jsonResponse)
+		if err != nil {
+			log.Error(ctx, "writing response failed", err)
+			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func createIndexName(s string) string {
+	now := time.Now()
+	return fmt.Sprintf("%s%d", s, now.UnixMicro())
 }

--- a/cmd/dp-search-api/main.go
+++ b/cmd/dp-search-api/main.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	elasticHTTPClient := dphttp.NewClient()
-	elasticSearchClient := elasticsearch.New(cfg.ElasticSearchAPIURL, dphttp.NewClient(), cfg.SignElasticsearchRequests, esSigner, cfg.AwsRegion, cfg.AwsService)
+	elasticSearchClient := elasticsearch.New(cfg.ElasticSearchAPIURL, dphttp.NewClient(), cfg.SignElasticsearchRequests, esSigner, cfg.AwsRegion, cfg.AwsService, cfg)
 	transformer := transformer.New()
 	svcList := service.NewServiceList(&service.Init{})
 

--- a/cmd/dp-search-api/main.go
+++ b/cmd/dp-search-api/main.go
@@ -6,8 +6,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/ONSdigital/dp-search-api/service"
-
 	esauth "github.com/ONSdigital/dp-elasticsearch/v2/awsauth"
 	elastic "github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	dphttp "github.com/ONSdigital/dp-net/http"
@@ -15,6 +13,7 @@ import (
 	"github.com/ONSdigital/dp-search-api/config"
 	"github.com/ONSdigital/dp-search-api/elasticsearch"
 	"github.com/ONSdigital/dp-search-api/query"
+	"github.com/ONSdigital/dp-search-api/service"
 	"github.com/ONSdigital/dp-search-api/transformer"
 	"github.com/ONSdigital/log.go/v2/log"
 )
@@ -77,7 +76,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := api.CreateAndInitialise(cfg, queryBuilder, elasticSearchClient, transformer, hc, apiErrors); err != nil {
+	if err := service.CreateAndInitialise(cfg, queryBuilder, elasticSearchClient, transformer, hc, apiErrors, svcList); err != nil {
 		log.Fatal(ctx, "error initialising API", err)
 		os.Exit(1)
 	}

--- a/cmd/dp-search-api/main.go
+++ b/cmd/dp-search-api/main.go
@@ -64,7 +64,8 @@ func main() {
 	}
 
 	elasticHTTPClient := dphttp.NewClient()
-	elasticSearchClient := elasticsearch.New(cfg.ElasticSearchAPIURL, dphttp.NewClient(), cfg.SignElasticsearchRequests, esSigner, cfg.AwsRegion, cfg.AwsService, cfg)
+	esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
+	elasticSearchClient := elasticsearch.New(cfg.ElasticSearchAPIURL, dphttp.NewClient(), cfg.SignElasticsearchRequests, esSigner, cfg.AwsRegion, cfg.AwsService, cfg, esClient)
 	transformer := transformer.New()
 	svcList := service.NewServiceList(&service.Init{})
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	SignElasticsearchRequests  bool          `envconfig:"SIGN_ELASTICSEARCH_REQUESTS"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
+	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
 }
 
 var cfg *Config
@@ -36,6 +37,7 @@ func Get() (*Config, error) {
 		SignElasticsearchRequests:  false,
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
+		ZebedeeURL:                 "http://localhost:8082",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -30,12 +30,12 @@ func Get() (*Config, error) {
 	cfg = &Config{
 		AwsRegion:                  "eu-west-1",
 		AwsService:                 "es",
-		BindAddr:                  ":23900",
-		ElasticSearchAPIURL:       "http://localhost:9200",
-		GracefulShutdownTimeout:   5 * time.Second,
-		SignElasticsearchRequests: false,
-		HealthCheckCriticalTimeout:           90 * time.Second,
-		HealthCheckInterval:                  30 * time.Second,
+		BindAddr:                   ":23900",
+		ElasticSearchAPIURL:        "http://localhost:9200",
+		GracefulShutdownTimeout:    5 * time.Second,
+		SignElasticsearchRequests:  false,
+		HealthCheckCriticalTimeout: 90 * time.Second,
+		HealthCheckInterval:        30 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -115,11 +114,11 @@ func (cli *Client) CreateNewEmptyIndex(ctx context.Context, indexName string) (b
 	indexCreated := false
 	status, err := cli.esClient.CreateIndex(ctx, indexName, GetSearchIndexSettings())
 	if err != nil {
-		log.Info(ctx, "error creating index. Make sure that ELASTIC_SEARCH_URL is set to the correct one - see README", log.Data{"ELASTIC_SEARCH_URL": cli.cfg.ElasticSearchAPIURL})
+		log.Error(ctx, "error creating index. Make sure that ELASTIC_SEARCH_URL is set to the correct one - see README", err, log.Data{"ELASTIC_SEARCH_URL": cli.cfg.ElasticSearchAPIURL})
 		return indexCreated, err
 	}
 	if status != http.StatusOK {
-		log.Error(ctx, "unexpected http status when creating index - "+strconv.Itoa(status), err)
+		log.Error(ctx, "unexpected http status when creating index", err, log.Data{"response_status": status, "index_name": indexName})
 		return indexCreated, err
 	}
 	indexCreated = true

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -115,11 +115,11 @@ func (cli *Client) CreateNewEmptyIndex(ctx context.Context, indexName string) (b
 	indexCreated := false
 	status, err := cli.esClient.CreateIndex(ctx, indexName, GetSearchIndexSettings())
 	if err != nil {
-		log.Error(ctx, "error creating index. Make sure that ELASTIC_SEARCH_URL is set to http://localhost:11200", err)
+		log.Info(ctx, "error creating index. Make sure that ELASTIC_SEARCH_URL is set to the correct one - see README", log.Data{"ELASTIC_SEARCH_URL": cli.cfg.ElasticSearchAPIURL})
 		return indexCreated, err
 	}
 	if status != http.StatusOK {
-		log.Error(ctx, "error creating index http status - "+strconv.Itoa(status), err)
+		log.Error(ctx, "unexpected http status when creating index - "+strconv.Itoa(status), err)
 		return indexCreated, err
 	}
 	indexCreated = true

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -3,16 +3,17 @@ package elasticsearch
 import (
 	"bytes"
 	"context"
-	dpelasticsearch "github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
-	"github.com/ONSdigital/dp-search-api/config"
 	"io/ioutil"
-	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	esauth "github.com/ONSdigital/dp-elasticsearch/v2/awsauth"
+	dpelasticsearch "github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	dphttp "github.com/ONSdigital/dp-net/http"
+	"github.com/ONSdigital/dp-search-api/config"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/pkg/errors"
 )
 
@@ -113,11 +114,11 @@ func (cli *Client) CreateNewEmptyIndex(ctx context.Context, indexName string) (b
 	indexCreated := false
 	status, err := esClient.CreateIndex(ctx, indexName, GetSearchIndexSettings())
 	if err != nil {
-		log.Fatal(ctx, "error creating index", err)
+		log.Error(ctx, "error creating index. Make sure that ELASTIC_SEARCH_URL is set to http://localhost:11200", err)
 		return indexCreated, err
 	}
 	if status != http.StatusOK {
-		log.Fatal(ctx, "error creating index http status - ", status)
+		log.Error(ctx, "error creating index http status - "+strconv.Itoa(status), err)
 		return indexCreated, err
 	}
 	indexCreated = true

--- a/elasticsearch/client_test.go
+++ b/elasticsearch/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	esauth "github.com/ONSdigital/dp-elasticsearch/v2/awsauth"
+	elastic "github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	"github.com/ONSdigital/dp-search-api/config"
 	"io/ioutil"
@@ -31,7 +32,8 @@ func TestSearch(t *testing.T) {
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
+			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg, esClient)
 
 			res, err := client.Search(context.Background(), "index", "doctype", []byte("search request"))
 			So(err, ShouldBeNil)
@@ -58,7 +60,8 @@ func TestSearch(t *testing.T) {
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
+			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg, esClient)
 
 			_, err = client.Search(context.Background(), "index", "doctype", []byte("search request"))
 			So(err, ShouldNotBeNil)
@@ -93,7 +96,8 @@ func TestMultiSearch(t *testing.T) {
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
+			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg, esClient)
 
 			res, err := client.MultiSearch(context.Background(), "index", "doctype", []byte("multiSearch request"))
 			So(err, ShouldBeNil)
@@ -118,7 +122,8 @@ func TestMultiSearch(t *testing.T) {
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
+			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg, esClient)
 
 			_, err = client.MultiSearch(context.Background(), "index", "doctype", []byte("search request"))
 			So(err, ShouldNotBeNil)
@@ -152,7 +157,8 @@ func TestGetStatus(t *testing.T) {
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
+			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg, esClient)
 
 			res, err := client.GetStatus(context.Background())
 			So(err, ShouldBeNil)
@@ -175,7 +181,8 @@ func TestGetStatus(t *testing.T) {
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
+			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg, esClient)
 
 			_, err = client.GetStatus(context.Background())
 			So(err, ShouldNotBeNil)
@@ -199,7 +206,8 @@ func TestGetStatus(t *testing.T) {
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
 
-			client := New("http://localhost:999", dphttpMock, true, testSigner, "es", "eu-west-1", cfg)
+			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
+			client := New("http://localhost:999", dphttpMock, true, testSigner, "es", "eu-west-1", cfg, esClient)
 
 			_, err = client.GetStatus(context.Background())
 			So(err, ShouldNotBeNil)

--- a/elasticsearch/client_test.go
+++ b/elasticsearch/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	esauth "github.com/ONSdigital/dp-elasticsearch/v2/awsauth"
 	dphttp "github.com/ONSdigital/dp-net/http"
+	"github.com/ONSdigital/dp-search-api/config"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +28,10 @@ func TestSearch(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
+			cfg, err := config.Get()
+			So(err, ShouldBeNil)
+
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
 
 			res, err := client.Search(context.Background(), "index", "doctype", []byte("search request"))
 			So(err, ShouldBeNil)
@@ -51,9 +55,12 @@ func TestSearch(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
+			cfg, err := config.Get()
+			So(err, ShouldBeNil)
 
-			_, err := client.Search(context.Background(), "index", "doctype", []byte("search request"))
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
+
+			_, err = client.Search(context.Background(), "index", "doctype", []byte("search request"))
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, "http error")
 			So(dphttpMock.DoCalls(), ShouldHaveLength, 1)
@@ -83,7 +90,10 @@ func TestMultiSearch(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
+			cfg, err := config.Get()
+			So(err, ShouldBeNil)
+
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
 
 			res, err := client.MultiSearch(context.Background(), "index", "doctype", []byte("multiSearch request"))
 			So(err, ShouldBeNil)
@@ -105,9 +115,12 @@ func TestMultiSearch(t *testing.T) {
 			}
 			var testSigner *esauth.Signer
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
+			cfg, err := config.Get()
+			So(err, ShouldBeNil)
 
-			_, err := client.MultiSearch(context.Background(), "index", "doctype", []byte("search request"))
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
+
+			_, err = client.MultiSearch(context.Background(), "index", "doctype", []byte("search request"))
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, "http error")
 			So(dphttpMock.DoCalls(), ShouldHaveLength, 1)
@@ -136,7 +149,10 @@ func TestGetStatus(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
+			cfg, err := config.Get()
+			So(err, ShouldBeNil)
+
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
 
 			res, err := client.GetStatus(context.Background())
 			So(err, ShouldBeNil)
@@ -156,9 +172,12 @@ func TestGetStatus(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
+			cfg, err := config.Get()
+			So(err, ShouldBeNil)
 
-			_, err := client.GetStatus(context.Background())
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", cfg)
+
+			_, err = client.GetStatus(context.Background())
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, "http error")
 			So(dphttpMock.DoCalls(), ShouldHaveLength, 1)
@@ -177,9 +196,12 @@ func TestGetStatus(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			client := New("http://localhost:999", dphttpMock, true, testSigner, "es", "eu-west-1")
+			cfg, err := config.Get()
+			So(err, ShouldBeNil)
 
-			_, err := client.GetStatus(context.Background())
+			client := New("http://localhost:999", dphttpMock, true, testSigner, "es", "eu-west-1", cfg)
+
+			_, err = client.GetStatus(context.Background())
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, "v4 signer missing. Cannot sign request")
 

--- a/elasticsearch/search-index-settings.json
+++ b/elasticsearch/search-index-settings.json
@@ -6,7 +6,7 @@
     },
     "analysis": {
       "analyzer": {
-        "default_index": {
+        "default": {
           "tokenizer": "keyword",
           "filter": [
             "trim",
@@ -17,7 +17,6 @@
           "tokenizer": "standard",
           "filter": [
             "lowercase",
-            "standard",
             "stop"
           ]
         },
@@ -26,7 +25,6 @@
           "filter": [
             "lowercase",
             "ons_synonyms",
-            "standard",
             "stop",
             "stem_exclusion",
             "snowball"
@@ -37,7 +35,6 @@
           "filter": [
             "lowercase",
             "ons_synonyms",
-            "standard",
             "stop"
           ]
         },
@@ -45,7 +42,6 @@
           "tokenizer": "standard",
           "filter": [
             "lowercase",
-            "standard",
             "stop",
             "stem_exclusion",
             "snowball"
@@ -57,7 +53,6 @@
           "filter": [
             "lowercase",
             "ons_synonyms",
-            "standard",
             "stop",
             "stem_exclusion",
             "snowball"
@@ -68,7 +63,6 @@
           "char_filter": "clear_dates",
           "filter": [
             "lowercase",
-            "standard",
             "stop",
             "stem_exclusion",
             "snowball"
@@ -192,87 +186,85 @@
     }
   },
   "mappings": {
-      "dynamic_date_formats": [
-        "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-      ],
-      "properties": {
-        "type": {
-          "type": "keyword"
-        },
-        "description": {
-          "properties": {
-            "cdid": {
-              "type": "text",
-              "analyzer": "ons_standard"
-            },
-            "datasetId": {
-              "type": "text",
-              "analyzer": "ons_standard"
-            },
-            "title": {
-              "type": "text",
-              "analyzer": "ons_synonym_stem",
-              "search_analyzer": "ons_stem",
-              "fields": {
-                "title_raw": {
-                  "type": "keywords"
-                },
-                "title_no_stem": {
-                  "type": "text",
-                  "analyzer": "ons_synonym",
-                  "search_analyzer": "ons_standard"
-                },
-                "title_no_synonym_no_stem": {
-                  "type": "text",
-                  "analyzer": "ons_standard"
-                },
-                "title_no_dates": {
-                  "type": "text",
-                  "analyzer": "ons_synonym_stem_clear_dates",
-                  "search_analyzer": "ons_stem_clear_dates"
-                },
-                "title_first_letter": {
-                  "type": "text",
-                  "analyzer": "first_letter"
-                }
+    "dynamic_date_formats": [
+      "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    ],
+    "properties": {
+      "type": {
+        "type": "keyword"
+      },
+      "description": {
+        "properties": {
+          "cdid": {
+            "type": "text",
+            "analyzer": "ons_standard"
+          },
+          "datasetId": {
+            "type": "text",
+            "analyzer": "ons_standard"
+          },
+          "title": {
+            "type": "text",
+            "analyzer": "ons_synonym_stem",
+            "search_analyzer": "ons_stem",
+            "fields": {
+              "title_raw": {
+                "type": "keyword"
+              },
+              "title_no_stem": {
+                "type": "text",
+                "analyzer": "ons_synonym",
+                "search_analyzer": "ons_standard"
+              },
+              "title_no_synonym_no_stem": {
+                "type": "text",
+                "analyzer": "ons_standard"
+              },
+              "title_no_dates": {
+                "type": "text",
+                "analyzer": "ons_synonym_stem_clear_dates",
+                "search_analyzer": "ons_stem_clear_dates"
+              },
+              "title_first_letter": {
+                "type": "text",
+                "analyzer": "first_letter"
               }
-            },
-            "edition": {
-              "type": "text",
-              "analyzer": "ons_synonym_stem",
-              "search_analyzer": "ons_stem"
-            },
-            "metaDescription": {
-              "type": "text",
-              "analyzer": "ons_standard"
-            },
-            "summary": {
-              "type": "text",
-              "analyzer": "ons_standard"
-            },
-            "keywords": {
-              "type": "text",
-              "analyzer": "ons_synonym_stem",
-              "search_analyzer": "ons_stem",
-              "fields": {
-                "keywords_raw": {
-                  "type": "text"
-                }
-              }
-            },
-            "releaseDate": {
-              "type": "date"
             }
-          }
-        },
-        "searchBoost": {
-          "type": "text",
-          "analyzer": "ons_synonym_stem",
-          "search_analyzer": "ons_stem",
-          "norms": {
-            "enabled": false
+          },
+          "edition": {
+            "type": "text",
+            "analyzer": "ons_synonym_stem",
+            "search_analyzer": "ons_stem"
+          },
+          "metaDescription": {
+            "type": "text",
+            "analyzer": "ons_standard"
+          },
+          "summary": {
+            "type": "text",
+            "analyzer": "ons_standard"
+          },
+          "keywords": {
+            "type": "text",
+            "analyzer": "ons_synonym_stem",
+            "search_analyzer": "ons_stem",
+            "fields": {
+              "keywords_raw": {
+                "type": "text"
+              }
+            }
+          },
+          "releaseDate": {
+            "type": "date"
           }
         }
+      },
+      "searchBoost": {
+        "type": "text",
+        "analyzer": "ons_synonym_stem",
+        "search_analyzer": "ons_stem",
+        "norms": false
+      }
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.17
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.41.1 // indirect
+	github.com/ONSdigital/dp-authorisation v0.1.0
 	github.com/ONSdigital/dp-elasticsearch/v2 v2.2.0
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
+	github.com/ONSdigital/dp-rchttp v1.0.0 // indirect
 	github.com/ONSdigital/go-ns v0.0.0-20210831102424-ebdecc20fe9e
 	github.com/ONSdigital/log.go v1.1.0 // indirect
 	github.com/ONSdigital/log.go/v2 v2.0.9

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,16 @@
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
+github.com/ONSdigital/dp-api-clients-go v1.9.0/go.mod h1:SM0b/NXDWndJ9EulmAGdfDY4DxPxK+pNsP8eZlIWiqM=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.41.1 h1:xkeT6dCTFSAoBpZxgiJUiuqgcfjCX+c52CIiZo1Y2iU=
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
+github.com/ONSdigital/dp-authorisation v0.1.0 h1:HzYwJdvk7ZAeB56KMAH6MP5+5uZuuJnEyGq6CViDoCg=
+github.com/ONSdigital/dp-authorisation v0.1.0/go.mod h1:rT81tcvWto5/cUWUFd0Q6gTqBoRfQmD6Qp0sq7FyiMg=
 github.com/ONSdigital/dp-elasticsearch/v2 v2.2.0 h1:dnHq+0WZtKXIb0tFK//lc/eG8TXLNMwt5k+UnCiwLfM=
 github.com/ONSdigital/dp-elasticsearch/v2 v2.2.0/go.mod h1:f85VX6TzHkq3pM/ddUzufoFNTcx3FOi7VN+SQG0vMbg=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
+github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-healthcheck v1.1.0 h1:fKOf8MMe8l4EW28ljX0wNZ5oZTgx/slAs7lyEx4eq2c=
 github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0rJ0+uHVGwxqdP4J5vg=
@@ -20,7 +24,10 @@ github.com/ONSdigital/dp-net v1.2.0 h1:gP9pBt/J8gktYeKsb7hq6uOC2xx1tfvTorUBNXp6p
 github.com/ONSdigital/dp-net v1.2.0/go.mod h1:NinlaqcsPbIR+X7j5PXCl3UI5G2zCL041SDF6WIiiO4=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
+github.com/ONSdigital/dp-rchttp v1.0.0 h1:K/1/gDtfMZCX1Mbmq80nZxzDirzneqA1c89ea26FqP4=
+github.com/ONSdigital/dp-rchttp v1.0.0/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
+github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad/go.mod h1:uHT6LaUlRbJsJRrIlN31t+QLUB80tAbk6ZR9sfoHL8Y=
 github.com/ONSdigital/go-ns v0.0.0-20210831102424-ebdecc20fe9e h1:tXdCJg2SUi2vLPA22bgVmeAY+sp3pKtUsAboBrOkO5Y=
 github.com/ONSdigital/go-ns v0.0.0-20210831102424-ebdecc20fe9e/go.mod h1:BCx4ULp5nT3dT7Mft5iMrp9439JG9lqIlc0JOPmsHTg=
 github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=
@@ -56,6 +63,7 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v0.0.0-20210202160940-bed99a852dfe h1:rcf1P0fm+1l0EjG16p06mYLj9gW9X36KgdHJ/88hS4g=
 github.com/gopherjs/gopherjs v0.0.0-20210202160940-bed99a852dfe/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -8,7 +8,7 @@ import (
 // ExternalServiceList holds the initialiser and initialisation state of external services.
 type ExternalServiceList struct {
 	HealthCheck bool
-	Init		Initialiser
+	Init        Initialiser
 }
 
 // NewServiceList creates a new service list with the provided initialiser

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	"github.com/ONSdigital/dp-search-api/api"
 	"github.com/ONSdigital/dp-search-api/config"
 	"net/http"
 )
@@ -11,6 +12,7 @@ import (
 // Initialiser defines the methods to initialise external services
 type Initialiser interface {
 	DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (HealthChecker, error)
+	DoGetAuthorisationHandlers(cfg *config.Config) api.AuthHandler
 }
 
 // HealthChecker defines the required methods from Healthcheck

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+
+	"github.com/ONSdigital/dp-search-api/api"
+	"github.com/ONSdigital/dp-search-api/config"
+	"github.com/ONSdigital/go-ns/server"
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+)
+
+var httpServer *server.Server
+
+// CreateAndInitialise initiates a new Search API
+func CreateAndInitialise(cfg *config.Config, queryBuilder api.QueryBuilder, elasticSearchClient api.ElasticSearcher, transformer api.ResponseTransformer, hc HealthChecker, errorChan chan error, svcList *ExternalServiceList) error {
+
+	if elasticSearchClient == nil {
+		return errors.New("CreateAndInitialise called without a valid elasticsearch client")
+	}
+
+	if queryBuilder == nil {
+		return errors.New("CreateAndInitialise called without a valid query builder")
+	}
+	router := mux.NewRouter()
+
+	errData := api.SetupData()
+	if errData != nil {
+		return errors.Wrap(errData, "Failed to setup data templates")
+	}
+
+	errTimeseries := api.SetupTimeseries()
+	if errTimeseries != nil {
+		return errors.Wrap(errTimeseries, "Failed to setup timeseries templates")
+	}
+
+	ctx := context.Background()
+	router.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
+	hc.Start(ctx)
+
+	permissions := svcList.GetAuthorisationHandlers(cfg)
+
+	api := api.NewSearchAPI(router, elasticSearchClient, queryBuilder, transformer, permissions)
+
+	httpServer = server.New(cfg.BindAddr, api.Router)
+
+	// Disable this here to allow service to manage graceful shutdown of the entire app.
+	httpServer.HandleOSSignals = false
+
+	go func() {
+		ctx := context.Background()
+		log.Info(ctx, "search api starting")
+		if err := httpServer.ListenAndServe(); err != nil {
+			log.Error(ctx, "search api http server returned error", err)
+			errorChan <- err
+		}
+	}()
+
+	return nil
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -133,11 +133,23 @@ paths:
         200:
           description: OK
           schema:
-            $ref: "#/definitions/SearchResponse"
+            $ref: "#/definitions/GetSearchResponse"
         400:
           description: Query term not specified
         500:
           description: Internal server error
+    post:
+     tags:
+       - search
+     summary: "Create new empty ONS Elasticsearch index"
+     description: "Request a new search index and receive the name of the new index created in response. Endpoint requires service or user authentication."
+     responses:
+       200:
+         description: OK
+         schema:
+           $ref: "#/definitions/PostSearchResponse"
+       500:
+         description: Internal server error
 
   /timeseries:
     get:
@@ -180,7 +192,7 @@ definitions:
               description: "Time taken to execute query in milliseconds"
               type: integer
 
-  SearchResponse:
+  GetSearchResponse:
     type: object
     properties:
       count:
@@ -217,6 +229,16 @@ definitions:
       - took
       - content_types
       - items
+
+  PostSearchResponse:
+    type: object
+    properties:
+      index_name:
+        type: string
+        description: "Name of new empty search index"
+        example: "ons1636458168532"
+    required:
+      - index_name
 
   DepartmentResponse:
     type: object


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Changes have been made for the purpose of the following story:

As an API user
I want to be able to create a new search index
so that I can easily update the existing search index with new functionality

These are the changes:

An endpoint has been added, which allows a POST request to be made, to create an empty ElasticSearch index. The index that's created is given a name of the following format:

ons{ISO8601 timestamp}

The endpoint is POST /search

It requires no parameters of any sort.

Example (to create a new empty index):
http://localhost:23900/search

Response:

{
    "IndexName": "ons1636628199823915"
}

NB. The new endpoint requires authorisation of type 'Bearer Token'. The token it needs is the SERVICE_AUTH_TOKEN so this must be set appropriately in whatever environment is being used. This also means that Zebedee (and Vault, which Zebedee has a dependency on) must now also be running in the same environment as this service. The README has been updated to reflect this.

# How to review
<!--- Describe in detail how you tested your changes. -->
If testing this locally then set up dependencies (see following steps).

In dp-compose run Site Wide ElasticSearch on port 11200 as follows:

 docker-compose up -d

In any directory run Vault as follows:

 vault server -dev

In the zebedee directory run Zebedee as follows:

 ./run.sh

Then in the dp-search-api run:

 make debug

The changes can then be tested locally using the POST URL:
http://localhost:23900/search

NB. Add 'Bearer Token' as the authorisation type and enter the value of your local $SERVICE_AUTH_TOKEN. 

The unit tests can be run using this command: make test

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
