### PR TITLE
Feature/deprecate old es client

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,10 +4,10 @@ package api
 
 import (
 	"context"
-	dpelastic "github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	"net/http"
 
 	"github.com/ONSdigital/dp-authorisation/auth"
+	dpelastic "github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
@@ -37,7 +37,6 @@ type ElasticSearcher interface {
 	Search(ctx context.Context, index string, docType string, request []byte) ([]byte, error)
 	MultiSearch(ctx context.Context, index string, docType string, request []byte) ([]byte, error)
 	GetStatus(ctx context.Context) ([]byte, error)
-	CreateNewEmptyIndex(ctx context.Context, indexName string) (bool, error)
 }
 
 // QueryBuilder provides methods for the search package
@@ -75,7 +74,7 @@ func NewSearchAPI(router *mux.Router, dpESClient *dpelastic.Client, deprecatedES
 	router.HandleFunc("/timeseries/{cdid}", TimeseriesLookupHandlerFunc(api.deprecatedESClient)).Methods("GET")
 	router.HandleFunc("/data", DataLookupHandlerFunc(api.deprecatedESClient)).Methods("GET")
 
-	createSearchIndexHandler := permissions.Require(update, CreateSearchIndexHandlerFunc(api.deprecatedESClient))
+	createSearchIndexHandler := permissions.Require(update, CreateSearchIndexHandlerFunc(api.dpESClient))
 	router.HandleFunc("/search", createSearchIndexHandler).Methods("POST")
 
 	return api, nil

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -8,13 +8,11 @@ import (
 	"time"
 
 	esauth "github.com/ONSdigital/dp-elasticsearch/v2/awsauth"
-	elastic "github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	dphttp "github.com/ONSdigital/dp-net/http"
-	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/pkg/errors"
 )
 
-// Client represents an instance of the elasticsearch client
+// Client represents an instance of the elasticsearch client - now deprecated
 type Client struct {
 	awsRegion    string
 	awsSDKSigner *esauth.Signer
@@ -22,18 +20,16 @@ type Client struct {
 	url          string
 	client       dphttp.Clienter
 	signRequests bool
-	esClient     *elastic.Client
 }
 
 // New creates a new elasticsearch client. Any trailing slashes from the URL are removed.
-func New(url string, client dphttp.Clienter, signRequests bool, awsSDKSigner *esauth.Signer, awsService string, awsRegion string, esClient *elastic.Client) *Client {
+func New(url string, client dphttp.Clienter, signRequests bool, awsSDKSigner *esauth.Signer, awsService string, awsRegion string) *Client {
 	return &Client{
 		awsSDKSigner: awsSDKSigner,
 		awsRegion:    awsRegion,
 		awsService:   awsService,
 		client:       client,
 		signRequests: signRequests,
-		esClient:     esClient,
 		url:          url,
 	}
 }
@@ -102,25 +98,6 @@ func (cli *Client) post(ctx context.Context, index string, docType string, actio
 	}
 
 	return response, err
-}
-
-//CreateNewEmptyIndex is a method that creates an empty Elasticsearch index with the given indexName
-//It returns true if the index was created successfully, otherwise false
-func (cli *Client) CreateNewEmptyIndex(ctx context.Context, indexName string) (bool, error) {
-	indexCreated := false
-	status, err := cli.esClient.CreateIndex(ctx, indexName, GetSearchIndexSettings())
-	if err != nil {
-		log.Error(ctx, "error creating index", err, log.Data{"response_status": status, "index_name": indexName})
-		return indexCreated, err
-	}
-
-	if status != http.StatusOK {
-		log.Error(ctx, "unexpected http status when creating index", err, log.Data{"response_status": status, "index_name": indexName})
-		return indexCreated, err
-	}
-
-	indexCreated = true
-	return indexCreated, err
 }
 
 func buildContext(index string, docType string) string {

--- a/elasticsearch/client_test.go
+++ b/elasticsearch/client_test.go
@@ -9,10 +9,7 @@ import (
 	"testing"
 
 	esauth "github.com/ONSdigital/dp-elasticsearch/v2/awsauth"
-	elastic "github.com/ONSdigital/dp-elasticsearch/v2/elasticsearch"
 	dphttp "github.com/ONSdigital/dp-net/http"
-	"github.com/ONSdigital/dp-search-api/config"
-
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -30,11 +27,7 @@ func TestSearch(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			cfg, err := config.Get()
-			So(err, ShouldBeNil)
-
-			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", esClient)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
 
 			res, err := client.Search(context.Background(), "index", "doctype", []byte("search request"))
 			So(err, ShouldBeNil)
@@ -58,13 +51,9 @@ func TestSearch(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			cfg, err := config.Get()
-			So(err, ShouldBeNil)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
 
-			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", esClient)
-
-			_, err = client.Search(context.Background(), "index", "doctype", []byte("search request"))
+			_, err := client.Search(context.Background(), "index", "doctype", []byte("search request"))
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, "http error")
 			So(dphttpMock.DoCalls(), ShouldHaveLength, 1)
@@ -94,11 +83,7 @@ func TestMultiSearch(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			cfg, err := config.Get()
-			So(err, ShouldBeNil)
-
-			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", esClient)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
 
 			res, err := client.MultiSearch(context.Background(), "index", "doctype", []byte("multiSearch request"))
 			So(err, ShouldBeNil)
@@ -120,13 +105,9 @@ func TestMultiSearch(t *testing.T) {
 			}
 			var testSigner *esauth.Signer
 
-			cfg, err := config.Get()
-			So(err, ShouldBeNil)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
 
-			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", esClient)
-
-			_, err = client.MultiSearch(context.Background(), "index", "doctype", []byte("search request"))
+			_, err := client.MultiSearch(context.Background(), "index", "doctype", []byte("search request"))
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, "http error")
 			So(dphttpMock.DoCalls(), ShouldHaveLength, 1)
@@ -155,11 +136,7 @@ func TestGetStatus(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			cfg, err := config.Get()
-			So(err, ShouldBeNil)
-
-			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", esClient)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
 
 			res, err := client.GetStatus(context.Background())
 			So(err, ShouldBeNil)
@@ -179,13 +156,9 @@ func TestGetStatus(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			cfg, err := config.Get()
-			So(err, ShouldBeNil)
+			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1")
 
-			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
-			client := New("http://localhost:999", dphttpMock, false, testSigner, "es", "eu-west-1", esClient)
-
-			_, err = client.GetStatus(context.Background())
+			_, err := client.GetStatus(context.Background())
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, "http error")
 			So(dphttpMock.DoCalls(), ShouldHaveLength, 1)
@@ -204,13 +177,9 @@ func TestGetStatus(t *testing.T) {
 
 			var testSigner *esauth.Signer
 
-			cfg, err := config.Get()
-			So(err, ShouldBeNil)
+			client := New("http://localhost:999", dphttpMock, true, testSigner, "es", "eu-west-1")
 
-			esClient := elastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
-			client := New("http://localhost:999", dphttpMock, true, testSigner, "es", "eu-west-1", esClient)
-
-			_, err = client.GetStatus(context.Background())
+			_, err := client.GetStatus(context.Background())
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, "v4 signer missing. Cannot sign request")
 

--- a/service/service.go
+++ b/service/service.go
@@ -80,7 +80,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	dpESClient := dpelastic.NewClient(cfg.ElasticSearchAPIURL, cfg.SignElasticsearchRequests, 5)
 
 	// Initialise deprecatedESClient
-	deprecatedESClient := elasticsearch.New(cfg.ElasticSearchAPIURL, elasticHTTPClient, cfg.SignElasticsearchRequests, esSigner, cfg.AwsRegion, cfg.AwsService, dpESClient)
+	deprecatedESClient := elasticsearch.New(cfg.ElasticSearchAPIURL, elasticHTTPClient, cfg.SignElasticsearchRequests, esSigner, cfg.AwsRegion, cfg.AwsService)
 
 	// Initialise query builder
 	queryBuilder, err := query.NewQueryBuilder()


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Changes have been made for the purpose of deprecating the old version of ElasticSearch (version 2.4.2) and of fixing the following story so that it works correctly using the new version of ElasticSearch (7.10):

As an API user
I want to be able to create a new search index
so that I can easily update the existing search index with new functionality

These are the changes:

- The SearchAPI client now contains the new ES client aswell as the old one. The new one has been named dpESClient and the old one has been renamed to deprecatedESClient.
- The CreateSearchIndexHandlerFunc now uses the new ES client directly (instead of calling it via the CreateNewEmptyIndex method, which has now been removed).
- The new ES client now gets created using the NewClientWithHTTPClientAndAwsSigner, instead of the NewClient method, so that it will be possible to use AWS signing when running it using the AWS managed ElasticSearch (e.g. on the develop-site domain).
- The registerCheckers function now gets the new ES client from the service instead of creating its own new ES client.

# How to review
<!--- Describe in detail how you tested your changes. -->
Follow README instructions to test any of the endpoints (including the new POST /search endpoint). 

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

NB. When pointing ELASTIC_SEARCH_URL to the deprecated ES client then the existing endpoints should all work but the new one should give an internal server error. Similarly, when pointing ELASTIC_SEARCH_URL to the new ES client then the new endpoint should work but the existing ones should give this error message:

Failed to transform search result

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
