### PR TITLE
build additional suggestions if more than one query term

### DIFF
--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -175,7 +175,8 @@ func (t *Transformer) TransformSearchResponse(ctx context.Context, responseData 
 
 	sr := t.transform(&source, highlight)
 
-	if sr.Count == 0 {
+	needAdditionalSuggestions := numberOfSearchTerms(query)
+	if needAdditionalSuggestions > 1 {
 		as := buildAdditionalSuggestionList(query)
 		sr.AdditionSuggestions = as
 	}
@@ -306,4 +307,9 @@ func buildAdditionalSuggestionList(query string) []string {
 		queryTerms = append(queryTerms, match[0])
 	}
 	return queryTerms
+}
+
+func numberOfSearchTerms(query string) int {
+	st := strings.Fields(query)
+	return len(st)
 }


### PR DESCRIPTION
### What

`BuildAdditionalSuggestions` is only called when there is more than one search query term

### How to review

Enter `deatfhskuh` in search input. Should not receive `deatfhskuh` as a suggested word. Review with this branch of frontend-search-controller: [https://github.com/ONSdigital/dp-frontend-search-controller/pull/50](url)

### Who can review

Anyone but me. 
![Screenshot 2021-11-29 at 14 13 53](https://user-images.githubusercontent.com/16807393/143883404-d6871e53-1a9d-405a-b077-fb989dea279f.png)

