### PR TITLE
fix query parameter type

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -98,10 +98,7 @@ paths:
         - in: query
           name: content_type
           description: "Comma separated list of content types to be returned."
-          type: array
-          uniqueItems: true
-          items:
-            type: string
+          type: string
           collectionFormat: csv
           required: false
         - in: query


### PR DESCRIPTION
### What

Change parameter type to `string`

### How to review

See that documentation states the `content_type` is `type: string`

### Who can review

Anyone but me. 
