### PR TITLE
Refactor POST /search to try to fix permissions issue

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -72,8 +72,7 @@ func NewSearchAPI(router *mux.Router, dpESClient *dpelastic.Client, deprecatedES
 	router.HandleFunc("/search", SearchHandlerFunc(queryBuilder, api.deprecatedESClient, api.Transformer)).Methods("GET")
 	router.HandleFunc("/timeseries/{cdid}", TimeseriesLookupHandlerFunc(api.deprecatedESClient)).Methods("GET")
 	router.HandleFunc("/data", DataLookupHandlerFunc(api.deprecatedESClient)).Methods("GET")
-
-	createSearchIndexHandler := permissions.Require(update, CreateSearchIndexHandlerFunc(api.dpESClient))
+	createSearchIndexHandler := permissions.Require(update, api.CreateSearchIndexHandlerFunc)
 	router.HandleFunc("/search", createSearchIndexHandler).Methods("POST")
 
 	return api, nil

--- a/api/search.go
+++ b/api/search.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	dpelastic "github.com/ONSdigital/dp-elasticsearch/v3/elasticsearch"
 	"github.com/ONSdigital/dp-search-api/elasticsearch"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/pkg/errors"
@@ -148,43 +147,41 @@ func SearchHandlerFunc(queryBuilder QueryBuilder, elasticSearchClient ElasticSea
 	}
 }
 
-func CreateSearchIndexHandlerFunc(dpESClient *dpelastic.Client) http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
-		ctx := req.Context()
-		indexName := createIndexName("ons")
-		fmt.Printf("Index created: %s\n", indexName)
-		indexCreated := true
+func (a SearchAPI) CreateSearchIndexHandlerFunc(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	indexName := createIndexName("ons")
+	fmt.Printf("Index created: %s\n", indexName)
+	indexCreated := true
 
-		status, err := dpESClient.CreateIndex(ctx, indexName, elasticsearch.GetSearchIndexSettings())
+	status, err := a.dpESClient.CreateIndex(ctx, indexName, elasticsearch.GetSearchIndexSettings())
+	if err != nil {
+		log.Error(ctx, "error creating index", err, log.Data{"response_status": status, "index_name": indexName})
+		indexCreated = false
+	}
+
+	if status != http.StatusOK {
+		log.Error(ctx, "unexpected http status when creating index", err, log.Data{"response_status": status, "index_name": indexName})
+		indexCreated = false
+	}
+
+	if !indexCreated {
 		if err != nil {
-			log.Error(ctx, "error creating index", err, log.Data{"response_status": status, "index_name": indexName})
-			indexCreated = false
+			log.Error(ctx, "creating index failed with this error", err)
 		}
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
+	}
 
-		if status != http.StatusOK {
-			log.Error(ctx, "unexpected http status when creating index", err, log.Data{"response_status": status, "index_name": indexName})
-			indexCreated = false
-		}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	createIndexResponse := CreateIndexResponse{IndexName: indexName}
+	jsonResponse, _ := json.Marshal(createIndexResponse)
 
-		if !indexCreated {
-			if err != nil {
-				log.Error(ctx, "creating index failed with this error", err)
-			}
-			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		createIndexResponse := CreateIndexResponse{IndexName: indexName}
-		jsonResponse, _ := json.Marshal(createIndexResponse)
-
-		_, err = w.Write(jsonResponse)
-		if err != nil {
-			log.Error(ctx, "writing response failed", err)
-			http.Error(w, serverErrorMessage, http.StatusInternalServerError)
-			return
-		}
+	_, err = w.Write(jsonResponse)
+	if err != nil {
+		log.Error(ctx, "writing response failed", err)
+		http.Error(w, serverErrorMessage, http.StatusInternalServerError)
+		return
 	}
 }
 


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
There is currently a bug that is preventing the POST /search endpoint from correctly requesting service authorisation permissions from Zebedee.

Instead of sending Zebedee something like this:

http://localhost:8082/serviceInstancePermissions -H 'Authorization: Bearer <SERVICE_AUTH_TOKEN>'

it appears to be sending something like this: 

http://localhost:8082/serviceInstancePermissions -H 'Authorization: AWS4-HMAC-SHA256 Credential=$LONG_HASH/20220127/eu-west-1/es/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-request-id, Signature=$very_long_hash'

This problem only occurs when the SIGN_ELASTICSEARCH_REQUESTS envionment variable is set to true i.e. it works correctly locally but fails in the develop environment.

The problem seems to be some sort of mix up between the httpClient that is used to request permissions from Zebedee and the one that is used for sending requests to ElasticSearch. Therefore the dpESClient has been removed from the CreateSearchIndexHandlerFunc header to see if that will fix the problem.

# How to review
<!--- Describe in detail how you tested your changes. -->
If testing this locally then set up dependencies (see following steps).

In dp-compose run MongoDB on port 27017 as follows:

 docker-compose up -d

In any directory run Vault as follows:

 vault server -dev

In the zebedee directory run Zebedee as follows:

 ./run.sh

In dp-search-api set up the correct value of ELASTIC_SEARCH_URL and then run the service:

 export ELASTIC_SEARCH_URL="http://localhost:11200"
 make debug

The POST /search endpoint can then be used as follows:

curl -X POST http://localhost:10901/search -H 'Authorization: Bearer <SERVICE_AUTH_TOKEN>'

If working correcly then it should return the name of a new ElasticSearch index e.g.

{
  "IndexName": "ons1637671309217282"
}

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
