### PR TITLE
Remove requirement for POST /search requests to have service authentication

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -12,10 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	update = auth.Permissions{Update: true}
-)
-
 // SearchAPI provides an API around elasticseach
 type SearchAPI struct {
 	Router             *mux.Router

--- a/api/api.go
+++ b/api/api.go
@@ -72,8 +72,7 @@ func NewSearchAPI(router *mux.Router, dpESClient *dpelastic.Client, deprecatedES
 	router.HandleFunc("/search", SearchHandlerFunc(queryBuilder, api.deprecatedESClient, api.Transformer)).Methods("GET")
 	router.HandleFunc("/timeseries/{cdid}", TimeseriesLookupHandlerFunc(api.deprecatedESClient)).Methods("GET")
 	router.HandleFunc("/data", DataLookupHandlerFunc(api.deprecatedESClient)).Methods("GET")
-	createSearchIndexHandler := permissions.Require(update, api.CreateSearchIndexHandlerFunc)
-	router.HandleFunc("/search", createSearchIndexHandler).Methods("POST")
+	router.HandleFunc("/search", api.CreateSearchIndexHandlerFunc).Methods("POST")
 
 	return api, nil
 }


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
There is currently a bug that is preventing the POST /search endpoint from correctly requesting service authorisation permissions from Zebedee.

Instead of sending Zebedee something like this:

http://localhost:8082/serviceInstancePermissions -H 'Authorization: Bearer <SERVICE_AUTH_TOKEN>'

it appears to be sending something like this: 

http://localhost:8082/serviceInstancePermissions -H 'Authorization: AWS4-HMAC-SHA256 Credential=$LONG_HASH/20220127/eu-west-1/es/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-request-id, Signature=$very_long_hash'

This problem only occurs when the SIGN_ELASTICSEARCH_REQUESTS envionment variable is set to true i.e. it works correctly locally but fails in the develop environment.

On investigation it seems probable that recent changes to dp-elasticsearch are overwriting the Authorisation header of all incoming requests to the Search API (if SIGN_ELASTICSEARCH_REQUESTS is true) so that any requests made, from any of the Search API endpoints, to the ElasticSearch client provided by dp-elasticsearch, will be pre-populated with a signed header for AWS authentication.

Since having AWS authentication to some extent removes the need for service authentication it seems that the quickest and simplest way to work around this bug is by simply removing the need for the POST /search endpoint to send zebedee a permissions request (for service authorisation). That is the purpose of this PR. 

Therefore the requirement for POST /search requests to have service authentication has been removed, from the call to the CreateSearchIndexHandlerFunc, to see if that will fix the problem.

# How to review
<!--- Describe in detail how you tested your changes. -->
If testing this locally then set up dependencies (see following steps).

In dp-compose run MongoDB on port 27017 as follows:

 docker-compose up -d

In any directory run Vault as follows:

 vault server -dev

In the zebedee directory run Zebedee as follows:

 ./run.sh

In dp-search-api set up the correct value of ELASTIC_SEARCH_URL and then run the service:

 export ELASTIC_SEARCH_URL="http://localhost:11200"
 make debug

The POST /search endpoint can then be used as follows:

curl -X POST http://localhost:10901/search

NB. Previously it would have needed to be called like this: curl -X POST http://localhost:10901/search -H 'Authorization: Bearer <SERVICE_AUTH_TOKEN>'

If working correctly then it should return the name of a new ElasticSearch index e.g.

{
  "IndexName": "ons1637671309217282"
}

The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
