### PR TITLE
Feature/add search release

### DIFF
--- a/elasticsearch/search-index-settings.json
+++ b/elasticsearch/search-index-settings.json
@@ -255,20 +255,40 @@
       "releaseDate":{
         "type":"date"
       },
+      "published":{
+        "type":"bool"
+      },
+      "cancelled":{
+        "type":"bool"
+      },
+      "finalised":{
+        "type":"bool"
+      },
+      "dateChanges":{
+        "type":"nested",
+        "properties":{
+          "previousDate":{
+            "type":"date"
+          },
+          "changeNotice":{
+            "type":"text"
+          }
+        }
+      },
       "topics":{
-        "type": "nested",
-           "properties": {
-            "topic_name": {
-              "type": "keyword",
-              "fields": {
-                 "topics_raw": {
-                  "type": "text",
-                  "analyzer":"ons_synonym_stem",
-                  "search_analyzer":"ons_stem"
-                }
+        "type":"nested",
+        "properties":{
+          "topic_name":{
+            "type":"keyword",
+            "fields":{
+              "topics_raw":{
+                "type":"text",
+                "analyzer":"ons_synonym_stem",
+                "search_analyzer":"ons_stem"
               }
             }
           }
+        }
       },
       "searchBoost":{
         "type":"text",

--- a/main_test.go
+++ b/main_test.go
@@ -57,7 +57,7 @@ func (c *ComponentTest) InitializeTestSuite(ctx *godog.TestSuiteContext) {
 	})
 }
 
-func TestMain(t *testing.T) {
+func TestComponent(t *testing.T) {
 	if *componentFlag {
 		status := 0
 

--- a/transformer/releasetransformer.go
+++ b/transformer/releasetransformer.go
@@ -1,0 +1,260 @@
+package transformer
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type ReleaseTransformer struct {
+	higlightReplacer *strings.Replacer
+}
+
+type SearchReleaseResponse struct {
+	Took      int       `json:"took"`
+	Limit     int       `json:"limit"`
+	Offset    int       `json:"offset"`
+	Breakdown Breakdown `json:"breakdown"`
+	Releases  []Release `json:"releases"`
+}
+
+type Breakdown struct {
+	Total       int `json:"total"`
+	Provisional int `json:"provisional,omitempty"`
+	Confirmed   int `json:"confirmed,omitempty"`
+	Postponed   int `json:"postponed,omitempty"`
+	Published   int `json:"published,omitempty"`
+	Cancelled   int `json:"cancelled,omitempty"`
+	Census      int `json:"census,omitempty"`
+}
+
+type Release struct {
+	URI         string             `json:"uri"`
+	Description ReleaseDescription `json:"description"`
+	Highlight   *highlight         `json:"highlight,omitempty"`
+}
+
+type ReleaseDescription struct {
+	Title              string          `json:"title"`
+	Summary            string          `json:"summary"`
+	ReleaseDate        string          `json:"release_date"`
+	Published          bool            `json:"published"`
+	Cancelled          bool            `json:"cancelled"`
+	Finalised          bool            `json:"finalised"`
+	Postponed          bool            `json:"postponed"`
+	Census             bool            `json:"census"`
+	NationalStatistic  bool            `json:"national_statistic"`
+	Keywords           []string        `json:"keywords,omitempty"`
+	NextRelease        string          `json:"next_release,omitempty"`
+	ProvisionalDate    string          `json:"provisional_date,omitempty"`
+	CancellationNotice []string        `json:"cancellation_notice,omitempty"`
+	Edition            string          `json:"edition,omitempty"`
+	DatasetID          string          `json:"dataset_id,omitempty"`
+	LatestRelease      *bool           `json:"latest_release,omitempty"`
+	MetaDescription    string          `json:"meta_description,omitempty"`
+	Language           string          `json:"language,omitempty"`
+	Source             string          `json:"source,omitempty"`
+	Contact            *releaseContact `json:"contact,omitempty"`
+}
+
+type releaseContact struct {
+	Name      string `json:"name"`
+	Telephone string `json:"telephone,omitempty"`
+	Email     string `json:"email"`
+}
+
+type highlight struct {
+	DatasetID       string   `json:"dataset_id,omitempty"`
+	Edition         string   `json:"edition,omitempty"`
+	Keywords        []string `json:"keywords,omitempty"`
+	MetaDescription string   `json:"meta_description,omitempty"`
+	Summary         string   `json:"summary,omitempty"`
+	Title           string   `json:"title,omitempty"`
+}
+
+// Structs representing the raw elastic search response
+
+type ESReleaseResponse struct {
+	Took     int                      `json:"took"`
+	TimedOut bool                     `json:"timed_out"`
+	Hits     ESReleaseResponseSummary `json:"hits"`
+}
+
+type ESReleaseResponseSummary struct {
+	Total int                    `json:"total"`
+	Hits  []ESReleaseResponseHit `json:"hits"`
+}
+
+type ESReleaseResponseHit struct {
+	Source    ESReleaseSourceDocument `json:"_source"`
+	Highlight ESReleaseHighlight      `json:"highlight"`
+}
+
+type ESReleaseSourceDocument struct {
+	URI         string       `json:"uri"`
+	DateChanges []dateChange `json:"dateChanges,omitempty"`
+
+	Description struct {
+		Title              string          `json:"title"`
+		Summary            string          `json:"summary"`
+		ReleaseDate        string          `json:"releaseDate,omitempty"`
+		Published          bool            `json:"published"`
+		Cancelled          bool            `json:"cancelled"`
+		Finalised          bool            `json:"finalised"`
+		Topics             []string        `json:"topics"`
+		NationalStatistic  bool            `json:"nationalStatistic,omitempty"`
+		Keywords           []string        `json:"keywords,omitempty"`
+		NextRelease        string          `json:"nextRelease,omitempty"`
+		CancellationNotice []string        `json:"cancellationNotice"`
+		ProvisionalDate    string          `json:"provisionalDate"`
+		Edition            string          `json:"edition,omitempty"`
+		DatasetID          string          `json:"datasetId,omitempty"`
+		LatestRelease      bool            `json:"latestRelease"`
+		MetaDescription    string          `json:"metaDescription,omitempty"`
+		Language           string          `json:"language,omitempty"`
+		Source             string          `json:"source,omitempty"`
+		Contact            *releaseContact `json:"contact,omitempty"`
+	} `json:"description"`
+}
+
+type dateChange struct {
+	PreviousDate string `json:"previousDate,omitempty"`
+	ChangeNotice string `json:"changeNotice,omitempty"`
+}
+
+type ESReleaseHighlight struct {
+	DescriptionTitle     []string `json:"description.title"`
+	DescriptionEdition   []string `json:"description.edition"`
+	DescriptionSummary   []string `json:"description.summary"`
+	DescriptionMeta      []string `json:"description.metaDescription"`
+	DescriptionKeywords  []string `json:"description.keywords"`
+	DescriptionDatasetID []string `json:"description.datasetId"`
+}
+
+func NewReleaseTransformer() *ReleaseTransformer {
+	highlightReplacer := strings.NewReplacer("<em class=\"highlight\">", "", "</em>", "")
+	return &ReleaseTransformer{
+		higlightReplacer: highlightReplacer,
+	}
+}
+
+// TransformSearchResponse transforms an elastic search response into a structure that matches the v1 api specification
+func (t *ReleaseTransformer) TransformSearchResponse(_ context.Context, responseData []byte, _ string, highlight bool) ([]byte, error) {
+	var source ESReleaseResponse
+
+	err := json.Unmarshal(responseData, &source)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to decode elastic search response")
+	}
+
+	sr := t.transform(&source, highlight)
+
+	transformedData, err := json.Marshal(sr)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to encode transformed response")
+	}
+
+	return transformedData, nil
+}
+
+func (t *ReleaseTransformer) transform(source *ESReleaseResponse, highlight bool) SearchReleaseResponse {
+	sr := SearchReleaseResponse{
+		Took:      source.Took,
+		Limit:     10,
+		Offset:    0,
+		Breakdown: Breakdown{Total: source.Hits.Total},
+		Releases:  []Release{},
+	}
+
+	for i := range source.Hits.Hits {
+		sr.Releases = append(sr.Releases, t.buildRelease(source.Hits.Hits[i], highlight))
+	}
+
+	return sr
+}
+
+func (t *ReleaseTransformer) buildRelease(hit ESReleaseResponseHit, highlightOn bool) Release {
+	sd := hit.Source.Description
+	hl := hit.Highlight
+
+	r := Release{
+		URI: hit.Source.URI,
+		Description: ReleaseDescription{
+			Title:       sd.Title,
+			Summary:     sd.Summary,
+			ReleaseDate: sd.ReleaseDate,
+			// The following 3 need to be added to source document (and indexed)
+			Published:         sd.Published,
+			Cancelled:         sd.Cancelled,
+			Finalised:         sd.Finalised,
+			Postponed:         isPostponed(hit.Source),
+			Census:            isCensus(hit.Source),
+			NationalStatistic: sd.NationalStatistic,
+			Keywords:          sd.Keywords,
+			NextRelease:       sd.NextRelease,
+			// The following 3 need to be added to source document
+			ProvisionalDate:    sd.ProvisionalDate,
+			CancellationNotice: sd.CancellationNotice,
+			Edition:            sd.Edition,
+			DatasetID:          sd.DatasetID,
+			// The following 1 needs to be added to source document
+			LatestRelease:   &sd.LatestRelease,
+			MetaDescription: sd.MetaDescription,
+			Language:        sd.Language,
+			Contact:         sd.Contact,
+			Source:          sd.Source,
+		},
+	}
+
+	if highlightOn {
+		r.Highlight = &highlight{
+			DatasetID:       t.overlayItem(hl.DescriptionDatasetID, sd.DatasetID, highlightOn),
+			Edition:         t.overlayItem(hl.DescriptionEdition, sd.Edition, highlightOn),
+			Keywords:        t.overlayList(hl.DescriptionKeywords, sd.Keywords, highlightOn),
+			MetaDescription: t.overlayItem(hl.DescriptionMeta, sd.MetaDescription, highlightOn),
+			Summary:         t.overlayItem(hl.DescriptionSummary, sd.Summary, highlightOn),
+			Title:           t.overlayItem(hl.DescriptionTitle, sd.Title, highlightOn),
+		}
+	}
+
+	return r
+}
+
+func isCensus(_ ESReleaseSourceDocument) bool {
+	return false
+}
+
+func isPostponed(release ESReleaseSourceDocument) bool {
+	return release.Description.Finalised && len(release.DateChanges) > 0
+}
+
+func (t *ReleaseTransformer) overlayItem(hl []string, def string, highlight bool) string {
+	if highlight && len(hl) > 0 {
+		return hl[0]
+	}
+
+	return def
+}
+
+func (t *ReleaseTransformer) overlayList(hlList, defaultList []string, highlight bool) []string {
+	if defaultList == nil || hlList == nil {
+		return nil
+	}
+
+	overlaid := make([]string, len(defaultList))
+	copy(overlaid, defaultList)
+	if highlight {
+		for _, hl := range hlList {
+			unformatted := t.higlightReplacer.Replace(hl)
+			for i, defItem := range overlaid {
+				if defItem == unformatted {
+					overlaid[i] = hl
+				}
+			}
+		}
+	}
+
+	return overlaid
+}

--- a/transformer/releasetransformer_test.go
+++ b/transformer/releasetransformer_test.go
@@ -1,0 +1,55 @@
+package transformer
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestTransformSearchReleaseResponse(t *testing.T) {
+	Convey("With a transformer initialised", t, func() {
+		ctx := context.Background()
+		transformer := NewReleaseTransformer()
+		So(t, ShouldNotBeNil)
+
+		Convey("Throws error on invalid JSON", func() {
+			sampleResponse := []byte(`{"invalid":"json"`)
+			_, err := transformer.TransformSearchResponse(ctx, sampleResponse, "test-query", true)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldResemble, "Failed to decode elastic search response: unexpected end of JSON input")
+		})
+
+		Convey("Converts an example response with highlighting", func() {
+			sampleResponse, err := os.ReadFile("testdata/search_release_es_response.json")
+			So(err, ShouldBeNil)
+			expected, err := os.ReadFile("testdata/search_release_expected_highlighted.json")
+			So(err, ShouldBeNil)
+
+			actual, err := transformer.TransformSearchResponse(ctx, sampleResponse, "test-query", true)
+			So(err, ShouldBeNil)
+			So(actual, ShouldNotBeEmpty)
+			var exp, act SearchReleaseResponse
+			So(json.Unmarshal(expected, &exp), ShouldBeNil)
+			So(json.Unmarshal(actual, &act), ShouldBeNil)
+			So(act, ShouldResemble, exp)
+		})
+
+		Convey("Converts an example response without highlighting", func() {
+			sampleResponse, err := os.ReadFile("testdata/search_release_es_response.json")
+			So(err, ShouldBeNil)
+			expected, err := os.ReadFile("testdata/search_release_expected_plain.json")
+			So(err, ShouldBeNil)
+
+			actual, err := transformer.TransformSearchResponse(ctx, sampleResponse, "test-query", false)
+			So(err, ShouldBeNil)
+			So(actual, ShouldNotBeEmpty)
+			var exp, act SearchResponse
+			So(json.Unmarshal(expected, &exp), ShouldBeNil)
+			So(json.Unmarshal(actual, &act), ShouldBeNil)
+			So(act, ShouldResemble, exp)
+		})
+	})
+}

--- a/transformer/testdata/search_release_es_response.json
+++ b/transformer/testdata/search_release_es_response.json
@@ -1,0 +1,101 @@
+{
+  "took":8,
+  "timed_out":false,
+  "_shards":{
+    "total":3,
+    "successful":3,
+    "failed":0
+  },
+  "hits":{
+    "total":2,
+    "max_score":null,
+    "hits":[
+      {
+        "_index":"ons1646652430467",
+        "_type":"release",
+        "_id":"/releases/estimatingsuicideamonghighereducationstudentsenglandandwales",
+        "_score":0.2374177,
+        "_source":{
+          "uri":"/releases/estimatingsuicideamonghighereducationstudentsenglandandwales",
+          "type":"release",
+          "description":{
+            "finalised":true,
+            "title":"Estimating suicide among higher education students, England and Wales: Experimental Statistics",
+            "summary":"Estimates of suicides among higher education students by sex, age and ethnicity. Analysis based on mortality records linked to Higher Education Statistics Agency (HESA) Student records. ",
+            "nationalStatistic":false,
+            "contact":{
+              "email":"mortality@ons.gov.uk",
+              "name":"Sarah Caul",
+              "telephone":"+44 (0)1633 456490"
+            },
+            "releaseDate":"2018-06-25T08:30:00.000Z",
+            "nextRelease":"",
+            "unit":"",
+            "preUnit":"",
+            "source":"",
+            "cancelled":false,
+            "cancellationNotice":[],
+            "published":true,
+            "provisionalDate":""
+          },
+          "searchBoost":[]
+        },
+        "highlight":{
+          "description.summary":[
+            "Estimates of suicides among higher <em class=\"ons-highlight\">education</em> students by sex, age and ethnicity. Analysis based on mortality records linked to Higher <em class=\"ons-highlight\">Education</em> Statistics Agency (HESA) Student records. "
+          ],
+          "description.title":[
+            "Estimating suicide among higher <em class=\"ons-highlight\">education</em> students, England and <em class=\"ons-highlight\">Wales</em>: Experimental Statistics"
+          ]
+        },
+        "sort":[
+          0.2374177,
+          1529915400000
+        ]
+      },
+      {
+        "_index":"ons1646652430467",
+        "_type":"release",
+        "_id":"/releases/youngpeoplenotineducationemploymentortrainingneetukaugust2018",
+        "_score":0.04704748,
+        "_source":{
+          "uri":"/releases/youngpeoplenotineducationemploymentortrainingneetukaugust2018",
+          "type":"release",
+          "description":{
+            "finalised":true,
+            "title":"Young people not in education, employment or training (NEET), UK: August 2018",
+            "summary":"Estimates of young people (aged 16 to 24) who are not in education, employment or training, by age and sex.",
+            "nationalStatistic":true,
+            "contact":{
+              "email":"yanitsa.petkova@ons.gov.uk",
+              "name":"Yanitsa Petkova ",
+              "telephone":"+44 (0)1633 651599 "
+            },
+            "releaseDate":"2018-08-23T08:30:00.000Z",
+            "nextRelease":"22 November 2018",
+            "unit":"",
+            "preUnit":"",
+            "source":"",
+            "cancelled":false,
+            "cancellationNotice":[],
+            "published":true,
+            "provisionalDate":""
+          },
+          "searchBoost":[]
+        },
+        "highlight":{
+          "description.summary":[
+            "Estimates of young people (aged 16 to 24) who are not in <em class=\"ons-highlight\">education</em>, employment or training, by age and sex."
+          ],
+          "description.title":[
+            "Young people not in <em class=\"ons-highlight\">education</em>, employment or training (NEET), UK: August <em class=\"ons-highlight\">2018</em>"
+          ]
+        },
+        "sort":[
+          0.04704748,
+          1535013000000
+        ]
+      }
+    ]
+  }
+}

--- a/transformer/testdata/search_release_expected_highlighted.json
+++ b/transformer/testdata/search_release_expected_highlighted.json
@@ -1,0 +1,59 @@
+{
+  "took":8,
+  "limit":10,
+  "offset":0,
+  "breakdown":{
+    "total":2
+  },
+  "releases":[
+    {
+      "uri":"/releases/estimatingsuicideamonghighereducationstudentsenglandandwales",
+      "description":{
+        "title":"Estimating suicide among higher education students, England and Wales: Experimental Statistics",
+        "summary":"Estimates of suicides among higher education students by sex, age and ethnicity. Analysis based on mortality records linked to Higher Education Statistics Agency (HESA) Student records. ",
+        "release_date":"2018-06-25T08:30:00.000Z",
+        "published":true,
+        "cancelled":false,
+        "finalised":true,
+        "postponed":false,
+        "census":false,
+        "national_statistic":false,
+        "latest_release":false,
+        "contact":{
+          "name":"Sarah Caul",
+          "telephone":"+44 (0)1633 456490",
+          "email":"mortality@ons.gov.uk"
+        }
+      },
+      "highlight":{
+        "summary":"Estimates of suicides among higher \u003cem class=\"ons-highlight\"\u003eeducation\u003c/em\u003e students by sex, age and ethnicity. Analysis based on mortality records linked to Higher \u003cem class=\"ons-highlight\"\u003eEducation\u003c/em\u003e Statistics Agency (HESA) Student records. ",
+        "title":"Estimating suicide among higher \u003cem class=\"ons-highlight\"\u003eeducation\u003c/em\u003e students, England and \u003cem class=\"ons-highlight\"\u003eWales\u003c/em\u003e: Experimental Statistics"
+      }
+    },
+    {
+      "uri":"/releases/youngpeoplenotineducationemploymentortrainingneetukaugust2018",
+      "description":{
+        "title":"Young people not in education, employment or training (NEET), UK: August 2018",
+        "summary":"Estimates of young people (aged 16 to 24) who are not in education, employment or training, by age and sex.",
+        "release_date":"2018-08-23T08:30:00.000Z",
+        "published":true,
+        "cancelled":false,
+        "finalised":true,
+        "postponed":false,
+        "census":false,
+        "national_statistic":true,
+        "next_release":"22 November 2018",
+        "latest_release":false,
+        "contact":{
+          "name":"Yanitsa Petkova ",
+          "telephone":"+44 (0)1633 651599 ",
+          "email":"yanitsa.petkova@ons.gov.uk"
+        }
+      },
+      "highlight":{
+        "summary":"Estimates of young people (aged 16 to 24) who are not in \u003cem class=\"ons-highlight\"\u003eeducation\u003c/em\u003e, employment or training, by age and sex.",
+        "title":"Young people not in \u003cem class=\"ons-highlight\"\u003eeducation\u003c/em\u003e, employment or training (NEET), UK: August \u003cem class=\"ons-highlight\"\u003e2018\u003c/em\u003e"
+      }
+    }
+  ]
+}

--- a/transformer/testdata/search_release_expected_plain.json
+++ b/transformer/testdata/search_release_expected_plain.json
@@ -1,0 +1,51 @@
+{
+  "took":8,
+  "limit":10,
+  "offset":0,
+  "breakdown":{
+    "total":2
+  },
+  "releases":[
+    {
+      "uri":"/releases/estimatingsuicideamonghighereducationstudentsenglandandwales",
+      "description":{
+        "title":"Estimating suicide among higher education students, England and Wales: Experimental Statistics",
+        "summary":"Estimates of suicides among higher education students by sex, age and ethnicity. Analysis based on mortality records linked to Higher Education Statistics Agency (HESA) Student records. ",
+        "release_date":"2018-06-25T08:30:00.000Z",
+        "published":true,
+        "cancelled":false,
+        "finalised":true,
+        "postponed":false,
+        "census":false,
+        "national_statistic":false,
+        "latest_release":false,
+        "contact":{
+          "name":"Sarah Caul",
+          "telephone":"+44 (0)1633 456490",
+          "email":"mortality@ons.gov.uk"
+        }
+      }
+    },
+    {
+      "uri":"/releases/youngpeoplenotineducationemploymentortrainingneetukaugust2018",
+      "description":{
+        "title":"Young people not in education, employment or training (NEET), UK: August 2018",
+        "summary":"Estimates of young people (aged 16 to 24) who are not in education, employment or training, by age and sex.",
+        "release_date":"2018-08-23T08:30:00.000Z",
+        "published":true,
+        "cancelled":false,
+        "finalised":true,
+        "postponed":false,
+        "census":false,
+        "national_statistic":true,
+        "next_release":"22 November 2018",
+        "latest_release":false,
+        "contact":{
+          "name":"Yanitsa Petkova ",
+          "telephone":"+44 (0)1633 651599 ",
+          "email":"yanitsa.petkova@ons.gov.uk"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### What

Phase 1 of adding Elastic Search (ES) capabilities for Release (Calendar) entries. These commits:
- update the ES index mapping for new searchable fields for Release entries
- add a new separate definition for Elastic Search Release search results, with a corresponding transformer. Note certain definitions are replicated here to try to isolate the 'release search' from the main search

### How to review

Check code and ensure all tests are passing

### Who can review

Anyone but someone familiar with dp-search-api would be best placed
