### PR TITLE
Extend script to load data from dataset api

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,8 @@ linters-settings:
     min-confidence: 0
   gocyclo:
     min-complexity: 15
+  gocognit:
+    min-complexity: 40
   maligned:
     suggest-new: true
   dupl:

--- a/clients/datasetapi.go
+++ b/clients/datasetapi.go
@@ -4,14 +4,21 @@ import (
 	"context"
 
 	datasetclient "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 )
 
 //go:generate moq -out mock/datasetapi.go -pkg mock . DatasetClient
 
-// DatasetAPIClient defines the zebedee client
+// DatasetAPIClient defines the dataset client
 type DatasetAPIClient interface {
 	GetDatasets(ctx context.Context, userAuthToken, serviceAuthToken, collectionID string, q *datasetclient.QueryParams) (m datasetclient.List, err error)
 	GetEditions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m []datasetclient.Edition, err error)
 	GetFullEditionsDetails(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m []datasetclient.EditionsDetails, err error)
 	GetVersionMetadata(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m datasetclient.Metadata, err error)
+}
+
+// ZebedeeClient defines the zebedee client
+type ZebedeeClient interface {
+	GetPublishedIndex(ctx context.Context, piRequest *zebedee.PublishedIndexRequestParams) (zebedee.PublishedIndex, error)
+	GetPublishedData(ctx context.Context, uriString string) ([]byte, error)
 }

--- a/clients/datasetapi.go
+++ b/clients/datasetapi.go
@@ -1,0 +1,17 @@
+package clients
+
+import (
+	"context"
+
+	datasetclient "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+)
+
+//go:generate moq -out mock/datasetapi.go -pkg mock . DatasetClient
+
+// DatasetAPIClient defines the zebedee client
+type DatasetAPIClient interface {
+	GetDatasets(ctx context.Context, userAuthToken, serviceAuthToken, collectionID string, q *datasetclient.QueryParams) (m datasetclient.List, err error)
+	GetEditions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m []datasetclient.Edition, err error)
+	GetFullEditionsDetails(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m []datasetclient.EditionsDetails, err error)
+	GetVersionMetadata(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m datasetclient.Metadata, err error)
+}

--- a/cmd/reindex/aws.go
+++ b/cmd/reindex/aws.go
@@ -14,8 +14,10 @@ func getConfig(ctx context.Context) cliConfig {
 			service:               "es",
 			tlsInsecureSkipVerify: false,
 		},
-		zebedeeURL:   "http://localhost:10050",
-		esURL:        "ES_URL_Replaceme",
-		signRequests: true,
+		zebedeeURL:       "http://localhost:10050",
+		esURL:            "ES_URL_Replaceme",
+		signRequests:     true,
+		datasetURL:       "http://localhost:10400",
+		ServiceAuthToken: "SAuthToken_Replaceme",
 	}
 }

--- a/cmd/reindex/local.go
+++ b/cmd/reindex/local.go
@@ -28,8 +28,10 @@ func getConfig(ctx context.Context) cliConfig {
 			service:               "es",
 			tlsInsecureSkipVerify: true,
 		},
-		esURL:        "http://localhost:9200",
-		signRequests: false,
-		zebedeeURL:   "http://localhost:8082",
+		esURL:            "http://localhost:9200",
+		signRequests:     false,
+		zebedeeURL:       "http://localhost:8082",
+		datasetURL:       "http://localhost:22000",
+		ServiceAuthToken: "",
 	}
 }

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -9,13 +9,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	dpEs "github.com/ONSdigital/dp-elasticsearch/v3"
 	dpEsClient "github.com/ONSdigital/dp-elasticsearch/v3/client"
 	v710 "github.com/ONSdigital/dp-elasticsearch/v3/client/elasticsearch/v710"
 	"github.com/ONSdigital/dp-net/v2/awsauth"
 	dphttp2 "github.com/ONSdigital/dp-net/v2/http"
+	"github.com/ONSdigital/dp-search-api/clients"
+	"github.com/ONSdigital/dp-search-api/config"
 	"github.com/ONSdigital/dp-search-api/elasticsearch"
+	"github.com/ONSdigital/dp-search-api/service"
 	extractorModels "github.com/ONSdigital/dp-search-data-extractor/models"
 	importerModels "github.com/ONSdigital/dp-search-data-importer/models"
 	"github.com/ONSdigital/dp-search-data-importer/transform"
@@ -24,13 +28,16 @@ import (
 var (
 	maxConcurrentExtractions = 20
 	maxConcurrentIndexings   = 30
+	DefaultPaginationLimit   = 500
 )
 
 type cliConfig struct {
-	aws          AWSConfig
-	zebedeeURL   string
-	esURL        string
-	signRequests bool
+	aws              AWSConfig
+	zebedeeURL       string
+	datasetURL       string
+	esURL            string
+	signRequests     bool
+	ServiceAuthToken string
 }
 
 type AWSConfig struct {
@@ -39,6 +46,12 @@ type AWSConfig struct {
 	region                string
 	service               string
 	tlsInsecureSkipVerify bool
+}
+
+type DatasetEditionMetadata struct {
+	id        string
+	editionID string
+	version   string
 }
 
 type zebedeeClient interface {
@@ -81,6 +94,11 @@ func main() {
 		esHTTPClient = dphttp2.NewClientWithTransport(awsSignerRT)
 	}
 
+	svcList := service.NewServiceList(&service.Init{})
+	datasetClient := svcList.GetDatasetClient(&config.Config{
+		DatasetAPIURL: cfg.datasetURL,
+	})
+
 	esClient, esClientErr := dpEs.NewClient(dpEsClient.Config{
 		ClientLib: dpEsClient.GoElasticV710,
 		Address:   cfg.esURL,
@@ -93,10 +111,12 @@ func main() {
 	if err := esClient.NewBulkIndexer(ctx); err != nil {
 		log.Fatal(ctx, "Failed to create new bulk indexer")
 	}
-
+	datasetChan := extractDatasets(ctx, datasetClient, cfg.ServiceAuthToken)
+	editionChan := retrieveDatasetEditions(ctx, datasetClient, datasetChan, cfg.ServiceAuthToken)
+	metadataChan := retrieveLatestMetadata(ctx, datasetClient, editionChan, cfg.ServiceAuthToken)
 	urisChan := uriProducer(ctx, zebClient)
 	extractedChan, extractionFailuresChan := docExtractor(ctx, zebClient, urisChan, maxConcurrentExtractions)
-	transformedChan := docTransformer(extractedChan)
+	transformedChan := docTransformer(extractedChan, metadataChan)
 	indexedChan := docIndexer(ctx, esClient, transformedChan, maxConcurrentIndexings)
 
 	summarize(indexedChan, extractionFailuresChan)
@@ -162,47 +182,90 @@ func extractDoc(ctx context.Context, z zebedeeClient, uriChan <-chan string, ext
 	}
 }
 
-func docTransformer(extractedChan <-chan Document) chan Document {
+func docTransformer(extractedChan chan Document, metadataChan chan dataset.Metadata) chan Document {
 	transformedChan := make(chan Document)
 	go func() {
-		defer close(transformedChan)
 		var wg sync.WaitGroup
-
-		for extractedDoc := range extractedChan {
-			wg.Add(1)
-			go func(doc Document) {
-				defer wg.Done()
-				transformDoc(doc, transformedChan)
-			}(extractedDoc)
+		for i := 0; i < maxConcurrentExtractions; i++ {
+			wg.Add(2)
+			go func(wg *sync.WaitGroup) {
+				transformZebedeeDoc(extractedChan, transformedChan, wg)
+				transformMetadataDoc(metadataChan, transformedChan, wg)
+			}(&wg)
 		}
 		wg.Wait()
+		close(transformedChan)
 		fmt.Println("Finished transforming docs")
 	}()
 	return transformedChan
 }
 
-func transformDoc(extractedDoc Document, transformedChan chan<- Document) {
-	var zebedeeData extractorModels.ZebedeeData
-	err := json.Unmarshal(extractedDoc.Body, &zebedeeData)
-	if err != nil {
-		log.Fatal("error while attempting to unmarshal zebedee response into zebedeeData", err) // TODO proper error handling
-	}
-	exporterEventData := extractorModels.MapZebedeeDataToSearchDataImport(zebedeeData, -1)
-	importerEventData := importerModels.SearchDataImportModel(exporterEventData)
-	esModel := transform.NewTransformer().TransformEventModelToEsModel(&importerEventData)
+func transformZebedeeDoc(extractedChan chan Document, transformedChan chan<- Document, wg *sync.WaitGroup) {
+	defer wg.Done()
+	var wg2 sync.WaitGroup
+	for extractedDoc := range extractedChan {
+		wg2.Add(1)
+		go func(extractedDoc Document) {
+			defer wg2.Done()
+			var zebedeeData extractorModels.ZebedeeData
+			err := json.Unmarshal(extractedDoc.Body, &zebedeeData)
+			if err != nil {
+				log.Fatal("error while attempting to unmarshal zebedee response into zebedeeData", err) // TODO proper error handling
+			}
+			exporterEventData := extractorModels.MapZebedeeDataToSearchDataImport(zebedeeData, -1)
+			importerEventData := importerModels.SearchDataImportModel(exporterEventData)
+			esModel := transform.NewTransformer().TransformEventModelToEsModel(&importerEventData)
 
-	body, err := json.Marshal(esModel)
-	if err != nil {
-		log.Fatal("error marshal to json", err) // TODO error handling
-		return
-	}
+			body, err := json.Marshal(esModel)
+			if err != nil {
+				log.Fatal("error marshal to json", err) // TODO error handling
+				return
+			}
 
-	transformedDoc := Document{
-		ID:   exporterEventData.UID,
-		URI:  extractedDoc.URI,
-		Body: body,
+			transformedDoc := Document{
+				ID:   exporterEventData.UID,
+				URI:  extractedDoc.URI,
+				Body: body,
+			}
+			transformedChan <- transformedDoc
+		}(extractedDoc)
 	}
-	transformedChan <- transformedDoc
+	wg2.Wait()
+}
+
+func transformMetadataDoc(metadataChan chan dataset.Metadata, transformedChan chan<- Document, wg *sync.WaitGroup) {
+	for metadata := range metadataChan {
+		cmdData := extractorModels.CMDData{
+			UID: metadata.DatasetDetails.ID,
+			VersionDetails: extractorModels.VersionDetails{
+				ReleaseDate: metadata.Version.ReleaseDate,
+			},
+			DatasetDetails: extractorModels.DatasetDetails{
+				Title:       metadata.DatasetDetails.Title,
+				Description: metadata.DatasetDetails.Description,
+			},
+		}
+		if metadata.DatasetDetails.Keywords != nil {
+			cmdData.DatasetDetails.Keywords = *metadata.DatasetDetails.Keywords
+		}
+		exporterEventData := extractorModels.MapVersionMetadataToSearchDataImport(cmdData)
+		importerEventData := importerModels.SearchDataImportModel(exporterEventData)
+		esModel := transform.NewTransformer().TransformEventModelToEsModel(&importerEventData)
+		body, err := json.Marshal(esModel)
+		if err != nil {
+			wg.Done()
+			log.Fatal("error marshal to json", err) // TODO error handling
+			return
+		}
+
+		transformedDoc := Document{
+			ID:   exporterEventData.UID,
+			URI:  metadata.URI,
+			Body: body,
+		}
+		transformedChan <- transformedDoc
+	}
+	wg.Done()
 }
 
 func docIndexer(ctx context.Context, dpEsIndexClient dpEsClient.Client, transformedChan chan Document, maxIndexings int) chan bool {
@@ -316,4 +379,90 @@ func deleteIndicies(ctx context.Context, dpEsIndexClient dpEsClient.Client, indi
 		log.Fatalf("Error: Indices.GetAlias: %s", err)
 	}
 	fmt.Printf("Deleted Indicies: %s\n", strings.Join(indicies, ","))
+}
+
+func extractDatasets(ctx context.Context, datasetClient clients.DatasetAPIClient, serviceAuthToken string) chan dataset.Dataset {
+	datasetChan := make(chan dataset.Dataset)
+	go func() {
+		defer close(datasetChan)
+		var list dataset.List
+		var err error
+		var offset = 0
+		for {
+			list, err = datasetClient.GetDatasets(ctx, "", serviceAuthToken, "", &dataset.QueryParams{
+				Offset: offset,
+				Limit:  DefaultPaginationLimit,
+			})
+			if err != nil {
+				log.Fatalf("Error: retrieving dataset clients: %v", err)
+			}
+			if len(list.Items) == 0 {
+				break
+			}
+			for i := 0; i < len(list.Items); i++ {
+				datasetChan <- list.Items[i]
+			}
+			offset += DefaultPaginationLimit
+		}
+	}()
+	return datasetChan
+}
+
+func retrieveDatasetEditions(ctx context.Context, datasetClient clients.DatasetAPIClient, datasetChan chan dataset.Dataset, serviceAuthToken string) chan DatasetEditionMetadata {
+	editionMetadataChan := make(chan DatasetEditionMetadata)
+	var wg sync.WaitGroup
+	go func() {
+		defer close(editionMetadataChan)
+		for i := 0; i < maxConcurrentExtractions; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for dataset := range datasetChan {
+					if dataset.Current == nil {
+						continue
+					}
+					editions, err := datasetClient.GetFullEditionsDetails(ctx, "", serviceAuthToken, dataset.CollectionID, dataset.Current.ID)
+					if err != nil {
+						log.Printf("error retrieving editions with dataset id: %v", dataset.ID)
+					} else {
+						for i := 0; i < len(editions); i++ {
+							if editions[i].ID == "" || editions[i].Current.Links.LatestVersion.ID == "" {
+								continue
+							}
+							editionMetadataChan <- DatasetEditionMetadata{
+								id:        dataset.Current.ID,
+								editionID: editions[i].Current.Edition,
+								version:   editions[i].Current.Links.LatestVersion.ID,
+							}
+						}
+					}
+				}
+			}()
+		}
+		wg.Wait()
+	}()
+	return editionMetadataChan
+}
+
+func retrieveLatestMetadata(ctx context.Context, datasetClient clients.DatasetAPIClient, editionMetadata chan DatasetEditionMetadata, serviceAuthToken string) chan dataset.Metadata {
+	metadataChan := make(chan dataset.Metadata)
+	var wg sync.WaitGroup
+	go func() {
+		defer close(metadataChan)
+		for i := 0; i < maxConcurrentExtractions; i++ {
+			wg.Add(1)
+			go func() {
+				for metadata := range editionMetadata {
+					metadata, err := datasetClient.GetVersionMetadata(ctx, "", serviceAuthToken, "", metadata.id, metadata.editionID, metadata.version)
+					if err != nil {
+						continue
+					}
+					metadataChan <- metadata
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	}()
+	return metadataChan
 }

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
+	DatasetAPIURL              string        `envconfig:"DATASET_API_URL"`
+	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN"`
 }
 
 type AWS struct {
@@ -43,6 +45,8 @@ func Get() (*Config, error) {
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		ZebedeeURL:                 "http://localhost:8082",
+		DatasetAPIURL:              "http://localhost:22000",
+		ServiceAuthToken:           "",
 	}
 
 	cfg.AWS = AWS{

--- a/elasticsearch/search-index-settings.json
+++ b/elasticsearch/search-index-settings.json
@@ -256,13 +256,13 @@
         "type":"date"
       },
       "published":{
-        "type":"bool"
+        "type":"boolean"
       },
       "cancelled":{
-        "type":"bool"
+        "type":"boolean"
       },
       "finalised":{
-        "type":"bool"
+        "type":"boolean"
       },
       "dateChanges":{
         "type":"nested",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.109.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.103.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-component-test v0.6.3
 	github.com/ONSdigital/dp-elasticsearch/v3 v3.0.0-alpha.2

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.92.2 h1:KlxSi4kRz9nO5j5OjCgnjQsyoRAky5WOmMKQPbNPHA8=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.92.2/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.103.0 h1:xMz8iARnoGZAMHCzOGxcxm8is/eBW7/I7qRUN5mYFXg=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.103.0/go.mod h1:/Pa0nFxsXQVkMz8ywCfx0dIa6OPbHRup7JRHsb6gBCU=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.109.0 h1:piB4N0px0205NrzjZB5J80Nh+dM/STjnB6pElmGORio=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.109.0/go.mod h1:/Pa0nFxsXQVkMz8ywCfx0dIa6OPbHRup7JRHsb6gBCU=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -3,13 +3,11 @@ package service
 import (
 	"net/http"
 
-	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	"github.com/ONSdigital/dp-authorisation/auth"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	api "github.com/ONSdigital/dp-search-api/api"
-	"github.com/ONSdigital/dp-search-api/clients"
 	"github.com/ONSdigital/dp-search-api/config"
 )
 
@@ -94,17 +92,4 @@ func (e *Init) DoGetAuthorisationHandlers(cfg *config.Config) api.AuthHandler {
 	)
 
 	return permissions
-}
-
-// GetDatasetClient return DatasetAPI client
-func (e *ExternalServiceList) GetDatasetClient(cfg *config.Config) clients.DatasetAPIClient {
-	datasetAPIClient := e.Init.DoGetDatasetClient(cfg)
-	e.DatasetClient = true
-	return datasetAPIClient
-}
-
-// DoGetZebedeeClient gets and initialises the Zebedee Client
-func (e *Init) DoGetDatasetClient(cfg *config.Config) clients.DatasetAPIClient {
-	datasetClient := dataset.NewAPIClient(cfg.DatasetAPIURL)
-	return datasetClient
 }

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -3,26 +3,30 @@ package service
 import (
 	"net/http"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	"github.com/ONSdigital/dp-authorisation/auth"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	api "github.com/ONSdigital/dp-search-api/api"
+	"github.com/ONSdigital/dp-search-api/clients"
 	"github.com/ONSdigital/dp-search-api/config"
 )
 
 // ExternalServiceList holds the initialiser and initialisation state of external services.
 type ExternalServiceList struct {
-	HealthCheck bool
-	Init        Initialiser
-	Auth        bool
+	HealthCheck   bool
+	Init          Initialiser
+	Auth          bool
+	DatasetClient bool
 }
 
 // NewServiceList creates a new service list with the provided initialiser
 func NewServiceList(initialiser Initialiser) *ExternalServiceList {
 	return &ExternalServiceList{
-		HealthCheck: false,
-		Init:        initialiser,
+		HealthCheck:   false,
+		Init:          initialiser,
+		DatasetClient: false,
 	}
 }
 
@@ -90,4 +94,17 @@ func (e *Init) DoGetAuthorisationHandlers(cfg *config.Config) api.AuthHandler {
 	)
 
 	return permissions
+}
+
+// GetDatasetClient return DatasetAPI client
+func (e *ExternalServiceList) GetDatasetClient(cfg *config.Config) clients.DatasetAPIClient {
+	datasetAPIClient := e.Init.DoGetDatasetClient(cfg)
+	e.DatasetClient = true
+	return datasetAPIClient
+}
+
+// DoGetZebedeeClient gets and initialises the Zebedee Client
+func (e *Init) DoGetDatasetClient(cfg *config.Config) clients.DatasetAPIClient {
+	datasetClient := dataset.NewAPIClient(cfg.DatasetAPIURL)
+	return datasetClient
 }

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-search-api/api"
-	"github.com/ONSdigital/dp-search-api/clients"
 	"github.com/ONSdigital/dp-search-api/config"
 )
 
@@ -21,7 +20,6 @@ type Initialiser interface {
 	DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer
 	DoGetHealthClient(name, url string) *health.Client
 	DoGetAuthorisationHandlers(cfg *config.Config) api.AuthHandler
-	DoGetDatasetClient(cfg *config.Config) clients.DatasetAPIClient
 }
 
 // HealthChecker defines the required methods from Healthcheck

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -6,12 +6,12 @@ package service
 
 import (
 	"context"
-
 	"net/http"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-search-api/api"
+	"github.com/ONSdigital/dp-search-api/clients"
 	"github.com/ONSdigital/dp-search-api/config"
 )
 
@@ -21,6 +21,7 @@ type Initialiser interface {
 	DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer
 	DoGetHealthClient(name, url string) *health.Client
 	DoGetAuthorisationHandlers(cfg *config.Config) api.AuthHandler
+	DoGetDatasetClient(cfg *config.Config) clients.DatasetAPIClient
 }
 
 // HealthChecker defines the required methods from Healthcheck

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -6,6 +6,7 @@ package mocks
 import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	api "github.com/ONSdigital/dp-search-api/api"
+	"github.com/ONSdigital/dp-search-api/clients"
 	"github.com/ONSdigital/dp-search-api/config"
 	"github.com/ONSdigital/dp-search-api/service"
 	"net/http"
@@ -44,6 +45,9 @@ type InitialiserMock struct {
 	// DoGetAuthorisationHandlersFunc mocks the DoGetAuthorisationHandlers method.
 	DoGetAuthorisationHandlersFunc func(cfg *config.Config) api.AuthHandler
 
+	// DoGetDatasetClientFunc mocks the DoGetDatasetClient method.
+	DoGetDatasetClientFunc func(cfg *config.Config) clients.DatasetAPIClient
+
 	// DoGetHTTPServerFunc mocks the DoGetHTTPServer method.
 	DoGetHTTPServerFunc func(bindAddr string, router http.Handler) service.HTTPServer
 
@@ -57,6 +61,11 @@ type InitialiserMock struct {
 	calls struct {
 		// DoGetAuthorisationHandlers holds details about calls to the DoGetAuthorisationHandlers method.
 		DoGetAuthorisationHandlers []struct {
+			// Cfg is the cfg argument value.
+			Cfg *config.Config
+		}
+		// DoGetDatasetClient holds details about calls to the DoGetDatasetClient method.
+		DoGetDatasetClient []struct {
 			// Cfg is the cfg argument value.
 			Cfg *config.Config
 		}
@@ -87,6 +96,7 @@ type InitialiserMock struct {
 		}
 	}
 	lockDoGetAuthorisationHandlers sync.RWMutex
+	lockDoGetDatasetClient         sync.RWMutex
 	lockDoGetHTTPServer            sync.RWMutex
 	lockDoGetHealthCheck           sync.RWMutex
 	lockDoGetHealthClient          sync.RWMutex
@@ -120,6 +130,38 @@ func (mock *InitialiserMock) DoGetAuthorisationHandlersCalls() []struct {
 	mock.lockDoGetAuthorisationHandlers.RLock()
 	calls = mock.calls.DoGetAuthorisationHandlers
 	mock.lockDoGetAuthorisationHandlers.RUnlock()
+	mock.lockDoGetAuthorisationHandlers.RUnlock()
+	return calls
+}
+
+// DoGetDatasetClient calls DoGetDatasetClientFunc.
+func (mock *InitialiserMock) DoGetDatasetClient(cfg *config.Config) clients.DatasetAPIClient {
+	if mock.DoGetDatasetClientFunc == nil {
+		panic("InitialiserMock.DoGetDatasetClientFunc: method is nil but Initialiser.DoGetDatasetClient was just called")
+	}
+	callInfo := struct {
+		Cfg *config.Config
+	}{
+		Cfg: cfg,
+	}
+	mock.lockDoGetDatasetClient.Lock()
+	mock.calls.DoGetDatasetClient = append(mock.calls.DoGetDatasetClient, callInfo)
+	mock.lockDoGetDatasetClient.Unlock()
+	return mock.DoGetDatasetClientFunc(cfg)
+}
+
+// DoGetDatasetClientCalls gets all the calls that were made to DoGetDatasetClient.
+// Check the length with:
+//     len(mockedInitialiser.DoGetDatasetClientCalls())
+func (mock *InitialiserMock) DoGetDatasetClientCalls() []struct {
+	Cfg *config.Config
+} {
+	var calls []struct {
+		Cfg *config.Config
+	}
+	mock.lockDoGetDatasetClient.RLock()
+	calls = mock.calls.DoGetDatasetClient
+	mock.lockDoGetDatasetClient.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

Extend script to load data from dataset api. This PR contains the following

- Make a request to get a list of datasets -> `/datasets`
- For each dataset, get the latests version of each edition,  -> `/datasets/<dataset_id>/editions` 
- For each edition of a dataset, get the latest version by calling `/datasets/<dataset_id>/editions/<edition>/versions/<latest version>/metadata`
- The data will then ned to be transformed to match the expected structure that will be stored in Elasticsearch


### How to review

This is tested in develop

### Who can review

Anyone except me (@nshumoogum  will be preferred as he is familiar with the script and its extension)
