### PR TITLE
Feature/add search release

### DIFF
--- a/query/releasesearch.go
+++ b/query/releasesearch.go
@@ -76,9 +76,9 @@ func ParseDate(date string) (Date, error) {
 	if date == "" {
 		return Date{}, nil
 	}
-	d, e := time.Parse(dateFormat, date)
-	if e != nil {
-		return Date{}, e
+	d, err := time.Parse(dateFormat, date)
+	if err != nil {
+		return Date{}, err
 	}
 
 	if d.Before(time.Date(1800, 1, 1, 0, 0, 0, 0, time.UTC)) {
@@ -93,8 +93,8 @@ func ParseDate(date string) (Date, error) {
 }
 
 func MustParseDate(date string) Date {
-	d, e := ParseDate(date)
-	if e != nil {
+	d, err := ParseDate(date)
+	if err != nil {
 		panic("invalid date string: " + date)
 	}
 
@@ -136,8 +136,8 @@ func ParseSort(sort string) (Sort, error) {
 }
 
 func MustParseSort(sort string) Sort {
-	s, e := ParseSort(sort)
-	if e != nil {
+	s, err := ParseSort(sort)
+	if err != nil {
 		panic("invalid sort string: " + sort)
 	}
 
@@ -195,9 +195,9 @@ type ReleaseSearchRequest struct {
 }
 
 func (sr *ReleaseSearchRequest) String() string {
-	s, e := json.MarshalIndent(sr, "", "  ")
-	if e != nil {
-		panic("couldn't marshal the searchRequest: " + e.Error())
+	s, err := json.MarshalIndent(sr, "", "  ")
+	if err != nil {
+		panic("couldn't marshal the searchRequest: " + err.Error())
 	}
 
 	return string(s)
@@ -205,9 +205,9 @@ func (sr *ReleaseSearchRequest) String() string {
 
 func (sr *ReleaseSearchRequest) Set(value string) error {
 	var sr2 ReleaseSearchRequest
-	e := json.Unmarshal([]byte(value), &sr2)
-	if e != nil {
-		return e
+	err := json.Unmarshal([]byte(value), &sr2)
+	if err != nil {
+		return err
 	}
 
 	*sr = sr2

--- a/query/releasesearch.go
+++ b/query/releasesearch.go
@@ -1,0 +1,215 @@
+package query
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+)
+
+type ParamValidator map[paramName]validator
+
+func (qpv ParamValidator) Validate(name, value string) (interface{}, error) {
+	if v, ok := qpv[paramName(name)]; ok {
+		return v(value)
+	}
+
+	return nil, fmt.Errorf("cannot validate: no validator for %s", name)
+}
+
+type validator func(param string) (interface{}, error)
+type paramName string
+
+func NewReleaseQueryParamValidator() ParamValidator {
+	return ParamValidator{
+		"limit": func(param string) (interface{}, error) {
+			value, err := strconv.Atoi(param)
+			if err != nil {
+				return 0, errors.New("limit search parameter provided with non numeric characters")
+			}
+			if value < 0 {
+				return 0, errors.New("limit search parameter provided with negative value")
+			}
+			if value > 5000 {
+				return 0, errors.New("limit search parameter provided with a value that is too high")
+			}
+
+			return value, nil
+		},
+		"offset": func(param string) (interface{}, error) {
+			value, err := strconv.Atoi(param)
+			if err != nil {
+				return 0, errors.New("offset search parameter provided with non numeric characters")
+			}
+			if value < 0 {
+				return 0, errors.New("offset search parameter provided with negative value")
+			}
+			return value, nil
+		},
+		"date": func(param string) (interface{}, error) {
+			value, err := ParseDate(param)
+			if err != nil {
+				return nil, fmt.Errorf("date search parameter provided is invalid: %w", err)
+			}
+			return value, nil
+		},
+		"sort": func(param string) (interface{}, error) {
+			value, err := ParseSort(param)
+			if err != nil {
+				return nil, fmt.Errorf("sort search parameter provided is invalid: %w", err)
+			}
+			return value, nil
+		},
+	}
+}
+
+type Date time.Time
+
+const dateFormat = "2006-01-02"
+
+func ParseDate(date string) (Date, error) {
+	if date == "" {
+		return Date{}, nil
+	}
+	d, e := time.Parse(dateFormat, date)
+	if e != nil {
+		return Date{}, e
+	}
+
+	if d.Before(time.Date(1800, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		return Date{}, errors.New("date too far in past")
+	}
+
+	if d.After(time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		return Date{}, errors.New("date too far in future")
+	}
+
+	return Date(d), nil
+}
+
+func MustParseDate(date string) Date {
+	d, e := ParseDate(date)
+	if e != nil {
+		panic("invalid date string: " + date)
+	}
+
+	return d
+}
+
+func (d Date) String() string {
+	return time.Time(d).UTC().Format(dateFormat)
+}
+
+func (d Date) ESString() string {
+	if time.Time(d).IsZero() {
+		return "null"
+	}
+	return fmt.Sprintf("%q", d.String())
+}
+
+type Sort int
+
+const (
+	Invalid Sort = iota
+	RelDateAsc
+	RelDateDesc
+	TitleAsc
+	TitleDesc
+)
+
+var sortNames = map[Sort]string{RelDateAsc: "release_date_asc", RelDateDesc: "release_date_desc", TitleAsc: "title_asc", TitleDesc: "title_desc", Invalid: "invalid"}
+var esSortNames = map[Sort]string{RelDateAsc: `{"description.releaseDate": "asc"}`, RelDateDesc: `{"description.releaseDate": "desc"}`, TitleAsc: `{"description.title": "asc"}`, TitleDesc: `{"description.title": "desc"}`, Invalid: "invalid"}
+
+func ParseSort(sort string) (Sort, error) {
+	for s, sn := range sortNames {
+		if strings.EqualFold(sort, sn) {
+			return s, nil
+		}
+	}
+
+	return Invalid, errors.New("invalid sort option string")
+}
+
+func MustParseSort(sort string) Sort {
+	s, e := ParseSort(sort)
+	if e != nil {
+		panic("invalid sort string: " + sort)
+	}
+
+	return s
+}
+
+func (s Sort) String() string {
+	return sortNames[s]
+}
+
+func (s Sort) ESString() string {
+	return esSortNames[s]
+}
+
+type ReleaseBuilder struct {
+	searchTemplates *template.Template
+}
+
+func NewReleaseBuilder(pathToTemplates string) (*ReleaseBuilder, error) {
+	searchTemplate, err := template.ParseFiles(
+		pathToTemplates+"templates/search/releasecalendar/search.tmpl",
+		pathToTemplates+"templates/search/releasecalendar/query.tmpl",
+		pathToTemplates+"templates/search/releasecalendar/upcoming.tmpl",
+		pathToTemplates+"templates/search/releasecalendar/published.tmpl")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load search template: %w", err)
+	}
+	return &ReleaseBuilder{
+		searchTemplates: searchTemplate,
+	}, nil
+}
+
+// BuildSearchQuery builds an elastic search query from the provided search parameters for Release Calendars
+func (sb *ReleaseBuilder) BuildSearchQuery(_ context.Context, sr ReleaseSearchRequest) ([]byte, error) {
+	var doc bytes.Buffer
+	err := sb.searchTemplates.Execute(&doc, sr)
+	if err != nil {
+		return nil, fmt.Errorf("creation of search from template failed: %w", err)
+	}
+
+	return doc.Bytes(), nil
+}
+
+type ReleaseSearchRequest struct {
+	Term           string
+	From           int
+	Size           int
+	SortBy         Sort
+	ReleasedAfter  Date
+	ReleasedBefore Date
+	Upcoming       bool
+	Published      bool
+	Highlight      bool
+	Now            Date
+}
+
+func (sr *ReleaseSearchRequest) String() string {
+	s, e := json.MarshalIndent(sr, "", "  ")
+	if e != nil {
+		panic("couldn't marshal the searchRequest: " + e.Error())
+	}
+
+	return string(s)
+}
+
+func (sr *ReleaseSearchRequest) Set(value string) error {
+	var sr2 ReleaseSearchRequest
+	e := json.Unmarshal([]byte(value), &sr2)
+	if e != nil {
+		return e
+	}
+
+	*sr = sr2
+	return nil
+}

--- a/query/releasesearch_test.go
+++ b/query/releasesearch_test.go
@@ -13,6 +13,7 @@ import (
 var validators = NewReleaseQueryParamValidator()
 
 func TestLimit(t *testing.T) {
+	t.Parallel()
 	Convey("given a limit validator, and a set of limits as strings", t, func() {
 		validator := validators["limit"]
 		limits := []struct {
@@ -37,6 +38,7 @@ func TestLimit(t *testing.T) {
 }
 
 func TestOffset(t *testing.T) {
+	t.Parallel()
 	Convey("given an offset validator, and a set of offsets as strings", t, func() {
 		validator := validators["offset"]
 		offsets := []struct {
@@ -61,6 +63,7 @@ func TestOffset(t *testing.T) {
 }
 
 func TestDates(t *testing.T) {
+	t.Parallel()
 	Convey("given a date validator, and a set of erroneous date strings", t, func() {
 		validator := validators["date"]
 		badDates := []string{"XXX", "Jan 21", "30/12/2021", "2021-13-31", "2021-12-32", "2021-02-29", "2300-12-31"}
@@ -85,6 +88,7 @@ func TestDates(t *testing.T) {
 }
 
 func TestSort(t *testing.T) {
+	t.Parallel()
 	Convey("given a sort validator, and a set of erroneous sort string options", t, func() {
 		validator := validators["sort"]
 		badSortOptions := []string{"dont sort", "sort-by-date", "date-ascending"}
@@ -120,6 +124,7 @@ func TestSort(t *testing.T) {
 }
 
 func TestBuildSearchReleaseQuery(t *testing.T) {
+	t.Parallel()
 	Convey("Should return InternalError for invalid template", t, func() {
 		qb := createReleaseQueryBuilderForTemplate("dummy{{.Moo}}")
 		query, err := qb.BuildSearchQuery(context.Background(), ReleaseSearchRequest{})

--- a/query/releasesearch_test.go
+++ b/query/releasesearch_test.go
@@ -1,0 +1,181 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"text/template"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var validators = NewReleaseQueryParamValidator()
+
+func TestLimit(t *testing.T) {
+	Convey("given a limit validator, and a set of limits as strings", t, func() {
+		validator := validators["limit"]
+		limits := []struct {
+			given   string
+			exValue int
+			exError error
+		}{
+			{given: "XXX", exValue: 0, exError: errors.New("limit search parameter provided with non numeric characters")},
+			{given: "-1", exValue: 0, exError: errors.New("limit search parameter provided with negative value")},
+			{given: "5001", exValue: 0, exError: fmt.Errorf("limit search parameter provided with a value that is too high")},
+			{given: "0", exValue: 0, exError: nil},
+			{given: "5000", exValue: 5000, exError: nil},
+		}
+
+		for _, ls := range limits {
+			v, e := validator(ls.given)
+
+			So(v, ShouldEqual, ls.exValue)
+			So(e, ShouldResemble, ls.exError)
+		}
+	})
+}
+
+func TestOffset(t *testing.T) {
+	Convey("given an offset validator, and a set of offsets as strings", t, func() {
+		validator := validators["offset"]
+		offsets := []struct {
+			given   string
+			exValue int
+			exError error
+		}{
+			{given: "XXX", exValue: 0, exError: errors.New("offset search parameter provided with non numeric characters")},
+			{given: "-1", exValue: 0, exError: errors.New("offset search parameter provided with negative value")},
+			{given: "0", exValue: 0, exError: nil},
+			{given: "1", exValue: 1, exError: nil},
+			{given: "15000", exValue: 15000, exError: nil},
+		}
+
+		for _, ls := range offsets {
+			v, e := validator(ls.given)
+
+			So(v, ShouldEqual, ls.exValue)
+			So(e, ShouldResemble, ls.exError)
+		}
+	})
+}
+
+func TestDates(t *testing.T) {
+	Convey("given a date validator, and a set of erroneous date strings", t, func() {
+		validator := validators["date"]
+		badDates := []string{"XXX", "Jan 21", "30/12/2021", "2021-13-31", "2021-12-32", "2021-02-29", "2300-12-31"}
+
+		Convey("errors are generated, and zero values returned on validation", func() {
+			for _, ds := range badDates {
+				v, e := validator(ds)
+
+				So(v, ShouldBeNil)
+				So(e, ShouldNotBeNil)
+			}
+		})
+
+		Convey("but a good date string is validated without error, and the appropriate Date returned", func() {
+			date := "2022-12-31"
+			v, e := validator(date)
+
+			So(v, ShouldResemble, MustParseDate(date))
+			So(e, ShouldBeNil)
+		})
+	})
+}
+
+func TestSort(t *testing.T) {
+	Convey("given a sort validator, and a set of erroneous sort string options", t, func() {
+		validator := validators["sort"]
+		badSortOptions := []string{"dont sort", "sort-by-date", "date-ascending"}
+
+		Convey("errors are generated, and zero values returned on validation", func() {
+			for _, ds := range badSortOptions {
+				v, e := validator(ds)
+
+				So(v, ShouldBeNil)
+				So(e, ShouldNotBeNil)
+			}
+		})
+
+		Convey("but a good sort option string is validated without error, and the appropriate Sort option returned", func() {
+			goodSortOptions := []struct {
+				given   string
+				exValue Sort
+			}{
+				{given: "release_date_asc", exValue: RelDateAsc},
+				{given: "release_date_desc", exValue: RelDateDesc},
+				{given: "title_asc", exValue: TitleAsc},
+				{given: "title_desc", exValue: TitleDesc},
+			}
+
+			for _, gso := range goodSortOptions {
+				v, e := validator(gso.given)
+
+				So(v, ShouldEqual, gso.exValue)
+				So(e, ShouldBeNil)
+			}
+		})
+	})
+}
+
+func TestBuildSearchReleaseQuery(t *testing.T) {
+	Convey("Should return InternalError for invalid template", t, func() {
+		qb := createReleaseQueryBuilderForTemplate("dummy{{.Moo}}")
+		query, err := qb.BuildSearchQuery(context.Background(), ReleaseSearchRequest{})
+
+		So(err, ShouldNotBeNil)
+		So(query, ShouldBeNil)
+		So(err.Error(), ShouldContainSubstring, "creation of search from template failed")
+	})
+
+	Convey("Should include all search parameters in elastic search query", t, func() {
+		qb := createReleaseQueryBuilderForTemplate("Term={{.Term}};" +
+			"From={{.From}};" +
+			"Size={{.Size}};" +
+			"SortBy={{.SortBy.ESString}};" +
+			"ReleasedAfter={{.ReleasedAfter.ESString}};" +
+			"ReleasedBefore={{.ReleasedBefore.ESString}};" +
+			"Upcoming={{.Upcoming}};" +
+			"Published={{.Published}};" +
+			"Highlight={{.Highlight}};" +
+			"Now={{.Now}};" +
+			"NowES={{.Now.ESString}}")
+
+		query, err := qb.BuildSearchQuery(context.Background(), ReleaseSearchRequest{
+			Term:           "query+term",
+			From:           0,
+			Size:           25,
+			SortBy:         TitleAsc,
+			ReleasedAfter:  Date{},
+			ReleasedBefore: MustParseDate("2020-12-31"),
+			Upcoming:       true,
+			Published:      false,
+			Highlight:      true,
+			Now:            MustParseDate("2001-01-01"),
+		})
+
+		So(err, ShouldBeNil)
+		So(query, ShouldNotBeNil)
+		queryString := string(query)
+		So(queryString, ShouldContainSubstring, "Term=query+term")
+		So(queryString, ShouldContainSubstring, "From=0")
+		So(queryString, ShouldContainSubstring, "Size=25")
+		So(queryString, ShouldContainSubstring, `SortBy={"description.title": "asc"}`)
+		So(queryString, ShouldContainSubstring, "ReleasedAfter=null")
+		So(queryString, ShouldContainSubstring, `ReleasedBefore="2020-12-31"`)
+		So(queryString, ShouldContainSubstring, "Upcoming=true")
+		So(queryString, ShouldContainSubstring, "Published=false")
+		So(queryString, ShouldContainSubstring, "Highlight=true")
+		So(queryString, ShouldContainSubstring, `Now=2001-01-01`)
+		So(queryString, ShouldContainSubstring, `NowES="2001-01-01"`)
+	})
+}
+
+func createReleaseQueryBuilderForTemplate(rawTemplate string) *ReleaseBuilder {
+	temp, err := template.New("search.tmpl").Parse(rawTemplate)
+	So(err, ShouldBeNil)
+	return &ReleaseBuilder{
+		searchTemplates: temp,
+	}
+}

--- a/templates/search/releasecalendar/main.go
+++ b/templates/search/releasecalendar/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	dphttp "github.com/ONSdigital/dp-net/v2/http"
+	"github.com/ONSdigital/dp-search-api/api"
+	"github.com/ONSdigital/dp-search-api/elasticsearch"
+	"github.com/ONSdigital/dp-search-api/query"
+	"github.com/ONSdigital/dp-search-api/transformer"
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+func main() {
+	var (
+		sr = query.ReleaseSearchRequest{
+			Size:           10,
+			SortBy:         query.RelDateDesc,
+			Term:           "Education in Wales",
+			ReleasedAfter:  query.MustParseDate("2018-01-01"),
+			ReleasedBefore: query.MustParseDate("2018-12-31"),
+			//Upcoming: true,
+			Published: true,
+			Highlight: false,
+			Now:       query.Date(time.Now()),
+		}
+		builder             *query.ReleaseBuilder
+		q, uq, responseData []byte
+		err                 error
+		ctx                                         = context.Background()
+		multi                                       = flag.Bool("multi", false, "use the multi query format when sending the query to ES")
+		file                                        = flag.String("file", "", "a file containing the actual query to be sent to ES (in json format)")
+		esClient                                    = elasticsearch.New("http://localhost:9200", dphttp.NewClient(), "eu-west-1", "es")
+		esSearch                                    = esClient.Search
+		esTransformer       api.ResponseTransformer = transformer.NewReleaseTransformer()
+	)
+
+	flag.Var(&sr, "sr", "a searchRequest object in json format")
+	flag.Parse()
+
+	log.Namespace = "dp-search-api/sitewide-test"
+
+	if *file != "" {
+		switch *file {
+		case "-":
+			q, err = io.ReadAll(os.Stdin)
+		default:
+			q, err = os.ReadFile(*file)
+		}
+		if err != nil {
+			log.Error(ctx, "failed to read query from file", err)
+			os.Exit(1)
+		}
+	} else {
+		builder, err = query.NewReleaseBuilder("../../../")
+		if err != nil {
+			log.Error(ctx, "failed to create builder", err)
+			os.Exit(2)
+		}
+
+		uq, err = builder.BuildSearchQuery(ctx, sr)
+		if err != nil {
+			log.Error(ctx, "failed to build query", err)
+			os.Exit(3)
+		}
+
+		var b bytes.Buffer
+		err = json.Compact(&b, uq)
+		if err != nil {
+			log.Error(ctx, "failed to compact query", err)
+			os.Exit(4)
+		}
+		q = b.Bytes()
+	}
+
+	if *multi {
+		q, err = query.FormatMultiQuery(append([]byte(`{"index" : "ons", "type": ["release"], "search_type": "dfs_query_then_fetch"}$$`), append(q, []byte(`$$`)...)...))
+		if err != nil {
+			log.Error(ctx, "failed to format multi query", err)
+			os.Exit(5)
+		}
+		esSearch = esClient.MultiSearch
+		esTransformer = transformer.New()
+	}
+
+	fmt.Printf("\nformatted query is:\n%s", q)
+	responseData, err = esSearch(ctx, "ons", "release", q)
+	if err != nil {
+		log.Error(ctx, "elasticsearch query failed", err)
+		return
+	}
+
+	if !json.Valid(responseData) {
+		log.Error(ctx, "elastic search returned invalid JSON for search query", errors.New("elastic search returned invalid JSON for search query"))
+		return
+	}
+	fmt.Printf("\nresponse is:\n%s", responseData)
+
+	responseData, err = esTransformer.TransformSearchResponse(ctx, responseData, sr.Term, sr.Highlight)
+	if err != nil {
+		log.Error(ctx, "transformation of response data failed", err)
+		return
+	}
+
+	fmt.Printf("\nprocessed response is:\n%s", responseData)
+}

--- a/templates/search/releasecalendar/published.tmpl
+++ b/templates/search/releasecalendar/published.tmpl
@@ -1,0 +1,47 @@
+{
+  "bool": {
+    "should": [
+      {
+        "bool": {
+          "must": [
+            {
+              "term": {
+                "description.published": true
+              }
+            },
+            {
+              "bool": {
+                "must_not": {
+                  "term": {
+                    "description.cancelled": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "bool": {
+          "must": [
+            {
+              "term": {
+                "description.cancelled": true
+              }
+            },
+            {
+              "range": {
+                "description.releaseDate": {
+                  "from": null,
+                  "to": {{.Now.ESString}},
+                  "include_lower": true,
+                  "include_upper": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/templates/search/releasecalendar/query.tmpl
+++ b/templates/search/releasecalendar/query.tmpl
@@ -1,0 +1,89 @@
+"dis_max": {
+    "queries": [
+        {
+            "bool": {
+                "should": [
+                    {
+                        "match": {
+                            "description.title.title_no_dates": {
+                                "query": "{{.Term}}",
+                                "type": "boolean",
+                                "boost": 10.0,
+                                "minimum_should_match": "1<-2 3<80% 5<60%"
+                            }
+                        }
+                    },
+                    {
+                        "match": {
+                            "description.title.title_no_stem": {
+                                "query": "{{.Term}}",
+                                "type": "boolean",
+                                "boost": 10.0,
+                                "minimum_should_match": "1<-2 3<80% 5<60%"
+                            }
+                        }
+                    },
+                    {
+                        "multi_match": {
+                            "query": "{{.Term}}",
+                            "fields": [
+                                "description.title^10",
+                                "description.edition"
+                           ],
+                            "type": "cross_fields",
+                            "minimum_should_match": "3<80% 5<60%"
+                         }
+                    },
+                    {
+                        "match": {
+                            "description.title.title_no_synonym_no_stem": {
+                                "query": "{{.Term}}",
+                                "type": "phrase_prefix",
+                                "max_expansions": 10
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "multi_match": {
+                "query": "{{.Term}}",
+                "fields": [
+                    "description.summary",
+                    "description.metaDescription"
+                ],
+                "type": "best_fields",
+                "minimum_should_match": "75%"
+            }
+        },
+        {
+            "match": {
+                "description.keywords": {
+                    "query": "{{.Term}}",
+                    "type": "boolean",
+                    "operator": "AND"
+                }
+            }
+        },
+        {
+            "multi_match": {
+                "query": "{{.Term}}",
+                "fields": [
+                    "description.cdid",
+                    "description.datasetId"
+                ]
+            }
+        },
+        {
+            "match": {
+                "searchBoost": {
+                    "query": "{{.Term}}",
+                    "type": "boolean",
+                    "operator": "AND",
+                    "boost": 100.0
+                }
+            }
+        }
+    ]
+}

--- a/templates/search/releasecalendar/search.tmpl
+++ b/templates/search/releasecalendar/search.tmpl
@@ -1,0 +1,52 @@
+{{- /*gotype:github.com/ONSdigital/dp-search-api/query.ReleaseSearchRequest*/ -}}
+{
+    "from": {{.From}},
+    "size": {{.Size}},
+    "sort": [
+        {{if .Term}} {"_score": "desc"}, {{- .SortBy.ESString -}}
+        {{else}} {{- .SortBy.ESString -}}
+        {{end}}
+    ],
+    "query": {
+        "bool": {
+            "must": {
+                {{if .Term}}
+                    {{- template "query.tmpl" . }}
+                {{else}}  "match_all": {}
+                {{end}}
+            },
+            "filter": [
+                {
+                    "range": {
+                         "description.releaseDate": {
+                            "from": {{.ReleasedAfter.ESString}},
+                            "to":  {{.ReleasedBefore.ESString}},
+                            "include_lower": true,
+                            "include_upper": true
+                        }
+                    }
+                }
+                {{if .Upcoming}}
+                    ,{{- template "upcoming.tmpl" . }}
+                {{else if .Published}}
+                    ,{{- template "published.tmpl" . }}
+                {{end}}
+            ]
+        }
+    }
+    {{if .Highlight}}
+        ,"highlight":{
+            "pre_tags":["<em class=\"ons-highlight\">"],
+            "post_tags":["</em>"],
+            "fields":{
+                "description.title":{"fragment_size":0,"number_of_fragments":0},
+                "description.summary":{"fragment_size":0,"number_of_fragments":0},
+                "description.edition":{"fragment_size":0,"number_of_fragments":0},
+                "description.metaDescription":{"fragment_size":0,"number_of_fragments":0},
+                "description.keywords":{"fragment_size":0,"number_of_fragments":0},
+                "description.datasetId":{"fragment_size":0,"number_of_fragments":0},
+                "description.cdid":{"fragment_size":0,"number_of_fragments":0}
+            }
+        }
+    {{end}}
+}

--- a/templates/search/releasecalendar/upcoming.tmpl
+++ b/templates/search/releasecalendar/upcoming.tmpl
@@ -1,0 +1,55 @@
+{
+  "bool": {
+    "should": [
+      {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must_not": {
+                  "term": {
+                    "description.published": true
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "must_not": {
+                  "term": {
+                    "description.cancelled": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "bool": {
+          "must": [
+            {
+              "term": {
+                "description.cancelled": true
+              }
+            },
+            {
+              "bool": {
+                "must_not": {
+                  "range": {
+                    "description.releaseDate": {
+                      "from": null,
+                      "to": {{.Now.ESString}},
+                      "include_lower": true,
+                      "include_upper": true
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/transformer/releasetransformer_test.go
+++ b/transformer/releasetransformer_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestTransformSearchReleaseResponse(t *testing.T) {
+	t.Parallel()
 	Convey("With a transformer initialised", t, func() {
 		ctx := context.Background()
 		transformer := NewReleaseTransformer()


### PR DESCRIPTION
### What

Phase 2 of adding Elastic Search (ES) capabilities for Release (Calendar) entries. These commits:
- Add templates for Elastic Search Release Calendar entry queries
- Add the ReleaseBuilder and logic for parsing and validating the query parameters
- Add a utility to build and/or execute queries against an Elastic search server

### How to review

Check code and ensure all tests are passing

### Who can review

Anyone but someone familiar with dp-search-api would be best placed
