### PR TITLE
Use es 7.10 client library

### DIFF
--- a/api/mocks.go
+++ b/api/mocks.go
@@ -6,6 +6,7 @@ package api
 import (
 	"context"
 	"github.com/ONSdigital/dp-authorisation/auth"
+	"github.com/ONSdigital/dp-elasticsearch/v3/client"
 	"github.com/ONSdigital/dp-search-api/query"
 	"net/http"
 	"sync"
@@ -168,6 +169,9 @@ var _ DpElasticSearcher = &DpElasticSearcherMock{}
 // 			CreateIndexFunc: func(ctx context.Context, indexName string, indexSettings []byte) error {
 // 				panic("mock out the CreateIndex method")
 // 			},
+// 			MultiSearchFunc: func(ctx context.Context, searches []client.Search) ([]byte, error) {
+// 				panic("mock out the MultiSearch method")
+// 			},
 // 		}
 //
 // 		// use mockedDpElasticSearcher in code that requires DpElasticSearcher
@@ -177,6 +181,9 @@ var _ DpElasticSearcher = &DpElasticSearcherMock{}
 type DpElasticSearcherMock struct {
 	// CreateIndexFunc mocks the CreateIndex method.
 	CreateIndexFunc func(ctx context.Context, indexName string, indexSettings []byte) error
+
+	// MultiSearchFunc mocks the MultiSearch method.
+	MultiSearchFunc func(ctx context.Context, searches []client.Search) ([]byte, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -189,8 +196,16 @@ type DpElasticSearcherMock struct {
 			// IndexSettings is the indexSettings argument value.
 			IndexSettings []byte
 		}
+		// MultiSearch holds details about calls to the MultiSearch method.
+		MultiSearch []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Searches is the searches argument value.
+			Searches []client.Search
+		}
 	}
 	lockCreateIndex sync.RWMutex
+	lockMultiSearch sync.RWMutex
 }
 
 // CreateIndex calls CreateIndexFunc.
@@ -229,6 +244,41 @@ func (mock *DpElasticSearcherMock) CreateIndexCalls() []struct {
 	mock.lockCreateIndex.RLock()
 	calls = mock.calls.CreateIndex
 	mock.lockCreateIndex.RUnlock()
+	return calls
+}
+
+// MultiSearch calls MultiSearchFunc.
+func (mock *DpElasticSearcherMock) MultiSearch(ctx context.Context, searches []client.Search) ([]byte, error) {
+	if mock.MultiSearchFunc == nil {
+		panic("DpElasticSearcherMock.MultiSearchFunc: method is nil but DpElasticSearcher.MultiSearch was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		Searches []client.Search
+	}{
+		Ctx:      ctx,
+		Searches: searches,
+	}
+	mock.lockMultiSearch.Lock()
+	mock.calls.MultiSearch = append(mock.calls.MultiSearch, callInfo)
+	mock.lockMultiSearch.Unlock()
+	return mock.MultiSearchFunc(ctx, searches)
+}
+
+// MultiSearchCalls gets all the calls that were made to MultiSearch.
+// Check the length with:
+//     len(mockedDpElasticSearcher.MultiSearchCalls())
+func (mock *DpElasticSearcherMock) MultiSearchCalls() []struct {
+	Ctx      context.Context
+	Searches []client.Search
+} {
+	var calls []struct {
+		Ctx      context.Context
+		Searches []client.Search
+	}
+	mock.lockMultiSearch.RLock()
+	calls = mock.calls.MultiSearch
+	mock.lockMultiSearch.RUnlock()
 	return calls
 }
 

--- a/api/search.go
+++ b/api/search.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ONSdigital/dp-elasticsearch/v3/client"
 	"github.com/ONSdigital/dp-search-api/elasticsearch"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/pkg/errors"
@@ -59,7 +60,110 @@ func paramGetBool(params url.Values, key string, defaultValue bool) bool {
 }
 
 // SearchHandlerFunc returns a http handler function handling search api requests.
-func SearchHandlerFunc(queryBuilder QueryBuilder, elasticSearchClient ElasticSearcher, transformer ResponseTransformer) http.HandlerFunc {
+func SearchHandlerFunc(queryBuilder QueryBuilder, elasticSearchClient DpElasticSearcher, transformer ResponseTransformer) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		params := req.URL.Query()
+
+		q := params.Get("q")
+		sort := paramGet(params, "sort", "relevance")
+
+		highlight := paramGetBool(params, "highlight", true)
+		topics := paramGet(params, "topics", "")
+		topicSlice := sanitiseURLParams(topics)
+		log.Info(ctx, "topic extracted and sanitised from the request url params", log.Data{
+			"param": "topics",
+			"value": topicSlice,
+		})
+		limitParam := paramGet(params, "limit", "10")
+		limit, err := strconv.Atoi(limitParam)
+		if err != nil {
+			log.Warn(ctx, "numeric search parameter provided with non numeric characters", log.Data{
+				"param": "limit",
+				"value": limitParam,
+			})
+			http.Error(w, "Invalid limit parameter", http.StatusBadRequest)
+			return
+		}
+		if limit < 0 {
+			log.Warn(ctx, "numeric search parameter provided with negative value", log.Data{
+				"param": "limit",
+				"value": limitParam,
+			})
+			http.Error(w, "Invalid limit parameter", http.StatusBadRequest)
+			return
+		}
+
+		offsetParam := paramGet(params, "offset", "0")
+		offset, err := strconv.Atoi(offsetParam)
+		if err != nil {
+			log.Warn(ctx, "numeric search parameter provided with non numeric characters", log.Data{
+				"param": "from",
+				"value": offsetParam,
+			})
+			http.Error(w, "Invalid offset parameter", http.StatusBadRequest)
+			return
+		}
+		if offset < 0 {
+			log.Warn(ctx, "numeric search parameter provided with negative value", log.Data{
+				"param": "from",
+				"value": offsetParam,
+			})
+			http.Error(w, "Invalid offset parameter", http.StatusBadRequest)
+			return
+		}
+
+		typesParam := paramGet(params, "content_type", defaultContentTypes)
+
+		formattedQuery, err := queryBuilder.BuildSearchQuery(ctx, q, typesParam, sort, topicSlice, limit, offset)
+		if err != nil {
+			log.Error(ctx, "creation of search query failed", err, log.Data{"q": q, "sort": sort, "limit": limit, "offset": offset})
+			http.Error(w, "Failed to create search query", http.StatusInternalServerError)
+			return
+		}
+
+		responseData, err := elasticSearchClient.MultiSearch(ctx, []client.Search{
+			{
+				Header: client.Header{
+					Index: "ons",
+				},
+				Query: formattedQuery,
+			},
+		})
+		if err != nil {
+			log.Error(ctx, "elasticsearch query failed", err)
+			http.Error(w, "Failed to run search query", http.StatusInternalServerError)
+			return
+		}
+
+		if !json.Valid(responseData) {
+			log.Error(ctx, "elastic search returned invalid JSON for search query", errors.New("elastic search returned invalid JSON for search query"))
+			http.Error(w, "Failed to process search query", http.StatusInternalServerError)
+			return
+		}
+
+		if !paramGetBool(params, "raw", false) {
+			responseData, err = transformer.TransformSearchResponse(ctx, responseData, q, highlight)
+			if err != nil {
+				log.Error(ctx, "transformation of response data failed", err)
+				http.Error(w, "Failed to transform search result", http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json;charset=utf-8")
+		_, err = w.Write(responseData)
+		if err != nil {
+			log.Error(ctx, "writing response failed", err)
+			http.Error(w, "Failed to write http response", http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+// LegacySearchHandlerFunc returns a http handler function handling search api requests.
+// TODO: This wil be deleted once the switch over is done to ES 7.10
+func LegacySearchHandlerFunc(queryBuilder QueryBuilder, elasticSearchClient ElasticSearcher, transformer ResponseTransformer) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		params := req.URL.Query()

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ONSdigital/dp-elasticsearch/v3/client"
+
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -25,7 +27,7 @@ const (
 func TestSearchHandlerFunc(t *testing.T) {
 	Convey("Should return BadRequest for invalid limit parameter", t, func() {
 		qbMock := newQueryBuilderMock(nil, nil)
-		esMock := newElasticSearcherMock(nil, nil)
+		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
 		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
@@ -43,7 +45,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 	Convey("Should return BadRequest for negative limit parameter", t, func() {
 		qbMock := newQueryBuilderMock(nil, nil)
-		esMock := newElasticSearcherMock(nil, nil)
+		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
 		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
@@ -61,7 +63,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 	Convey("Should return BadRequest for invalid offset parameter", t, func() {
 		qbMock := newQueryBuilderMock(nil, nil)
-		esMock := newElasticSearcherMock(nil, nil)
+		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
 		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
@@ -79,7 +81,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 	Convey("Should return BadRequest for negative offset parameter", t, func() {
 		qbMock := newQueryBuilderMock(nil, nil)
-		esMock := newElasticSearcherMock(nil, nil)
+		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
 		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
@@ -97,7 +99,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 	Convey("Should return InternalError for errors returned from query builder", t, func() {
 		qbMock := newQueryBuilderMock(nil, errors.New("Something"))
-		esMock := newElasticSearcherMock(nil, nil)
+		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
 		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
@@ -116,10 +118,303 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 	Convey("Should return InternalError for errors returned from elastic search", t, func() {
 		qbMock := newQueryBuilderMock([]byte(validQueryDoc), nil)
-		esMock := newElasticSearcherMock(nil, errors.New("Something"))
+		esMock := newDpElasticSearcherMock(nil, errors.New("Something"))
 		trMock := newResponseTransformerMock(nil, nil)
 
 		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam, nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+		So(resp.Body.String(), ShouldContainSubstring, "Failed to run search query")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Q, ShouldResemble, validQueryParam)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)
+		actualRequest := string(esMock.MultiSearchCalls()[0].Searches[0].Query)
+		So(actualRequest, ShouldResemble, validQueryDoc)
+	})
+
+	Convey("Should return InternalError for invalid json from elastic search", t, func() {
+		qbMock := newQueryBuilderMock([]byte(validQueryDoc), nil)
+		esMock := newDpElasticSearcherMock([]byte(`{"dummy":"response"`), nil)
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam, nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+		So(resp.Body.String(), ShouldContainSubstring, "Failed to process search query")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Q, ShouldResemble, validQueryParam)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)
+		actualRequest := string(esMock.MultiSearchCalls()[0].Searches[0].Query)
+		So(actualRequest, ShouldResemble, validQueryDoc)
+	})
+
+	Convey("Should return InternalError for transformation failures", t, func() {
+		qbMock := newQueryBuilderMock([]byte(validQueryDoc), nil)
+		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
+		trMock := newResponseTransformerMock(nil, errors.New("Something"))
+
+		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam, nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+		So(resp.Body.String(), ShouldContainSubstring, "Failed to transform search result")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Q, ShouldResemble, validQueryParam)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)
+		actualRequest := string(esMock.MultiSearchCalls()[0].Searches[0].Query)
+		So(actualRequest, ShouldResemble, validQueryDoc)
+		So(trMock.TransformSearchResponseCalls(), ShouldHaveLength, 1)
+		actualResponse := string(trMock.TransformSearchResponseCalls()[0].ResponseData)
+		So(actualResponse, ShouldResemble, validESResponse)
+	})
+
+	Convey("Should return OK for valid search result with raw=true", t, func() {
+		qbMock := newQueryBuilderMock([]byte(validQueryDoc), nil)
+		esMock := newDpElasticSearcherMock([]byte(`{"dummy":"response"}`), nil)
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?q=a&raw=true", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusOK)
+		So(resp.Body.String(), ShouldResemble, `{"dummy":"response"}`)
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Q, ShouldResemble, validQueryParam)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)
+		actualRequest := string(esMock.MultiSearchCalls()[0].Searches[0].Query)
+		So(actualRequest, ShouldResemble, validQueryDoc)
+		So(trMock.TransformSearchResponseCalls(), ShouldHaveLength, 0)
+	})
+
+	Convey("Should return OK for valid search result", t, func() {
+		qbMock := newQueryBuilderMock([]byte(validQueryDoc), nil)
+		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
+		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
+
+		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam, nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusOK)
+		So(resp.Body.String(), ShouldResemble, validTransformedResponse)
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Q, ShouldResemble, validQueryParam)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)
+		actualRequest := string(esMock.MultiSearchCalls()[0].Searches[0].Query)
+		So(actualRequest, ShouldResemble, validQueryDoc)
+		So(trMock.TransformSearchResponseCalls(), ShouldHaveLength, 1)
+		So(trMock.TransformSearchResponseCalls()[0].Highlight, ShouldBeTrue)
+		actualResponse := string(trMock.TransformSearchResponseCalls()[0].ResponseData)
+		So(actualResponse, ShouldResemble, validESResponse)
+	})
+
+	Convey("Should return OK for valid search result with highlight = true", t, func() {
+		qbMock := newQueryBuilderMock([]byte(validQueryDoc), nil)
+		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
+		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
+
+		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam+"&highlight=true", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusOK)
+		So(resp.Body.String(), ShouldResemble, validTransformedResponse)
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Q, ShouldResemble, validQueryParam)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)
+		actualRequest := string(esMock.MultiSearchCalls()[0].Searches[0].Query)
+		So(actualRequest, ShouldResemble, validQueryDoc)
+		So(trMock.TransformSearchResponseCalls(), ShouldHaveLength, 1)
+		So(trMock.TransformSearchResponseCalls()[0].Highlight, ShouldBeTrue)
+		actualResponse := string(trMock.TransformSearchResponseCalls()[0].ResponseData)
+		So(actualResponse, ShouldResemble, validESResponse)
+	})
+
+	Convey("Should return OK for valid search result with highlight = false", t, func() {
+		qbMock := newQueryBuilderMock([]byte(validQueryDoc), nil)
+		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
+		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
+
+		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam+"&highlight=false", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusOK)
+		So(resp.Body.String(), ShouldResemble, validTransformedResponse)
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Q, ShouldResemble, validQueryParam)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)
+		actualRequest := string(esMock.MultiSearchCalls()[0].Searches[0].Query)
+		So(actualRequest, ShouldResemble, validQueryDoc)
+		So(trMock.TransformSearchResponseCalls(), ShouldHaveLength, 1)
+		So(trMock.TransformSearchResponseCalls()[0].Highlight, ShouldBeFalse)
+		actualResponse := string(trMock.TransformSearchResponseCalls()[0].ResponseData)
+		So(actualResponse, ShouldResemble, validESResponse)
+	})
+
+	Convey("Should pass all search terms on to elastic search", t, func() {
+		qbMock := newQueryBuilderMock([]byte(validQueryDoc), nil)
+		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
+		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
+
+		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest(
+			"GET",
+			"http://localhost:8080/search?q="+validQueryParam+
+				"&content_type=ta,tb"+
+				"&sort_order=relevance"+
+				"&limit=1"+
+				"&offset=2",
+			nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusOK)
+		So(resp.Body.String(), ShouldResemble, validTransformedResponse)
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Q, ShouldResemble, validQueryParam)
+		So(qbMock.BuildSearchQueryCalls()[0].ContentTypes, ShouldResemble, "ta,tb")
+		So(qbMock.BuildSearchQueryCalls()[0].Sort, ShouldResemble, "relevance")
+		So(qbMock.BuildSearchQueryCalls()[0].Limit, ShouldEqual, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Offset, ShouldEqual, 2)
+
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)
+		actualRequest := string(esMock.MultiSearchCalls()[0].Searches[0].Query)
+		So(actualRequest, ShouldResemble, validQueryDoc)
+
+		So(trMock.TransformSearchResponseCalls(), ShouldHaveLength, 1)
+		actualResponse := string(trMock.TransformSearchResponseCalls()[0].ResponseData)
+		So(actualResponse, ShouldResemble, validESResponse)
+	})
+}
+
+func TestLegacySearchHandlerFunc(t *testing.T) {
+	Convey("Should return BadRequest for invalid limit parameter", t, func() {
+		qbMock := newQueryBuilderMock(nil, nil)
+		esMock := newElasticSearcherMock(nil, nil)
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?limit=a", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusBadRequest)
+		So(resp.Body.String(), ShouldContainSubstring, "Invalid limit parameter")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 0)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 0)
+	})
+
+	Convey("Should return BadRequest for negative limit parameter", t, func() {
+		qbMock := newQueryBuilderMock(nil, nil)
+		esMock := newElasticSearcherMock(nil, nil)
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?limit=-1", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusBadRequest)
+		So(resp.Body.String(), ShouldContainSubstring, "Invalid limit parameter")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 0)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 0)
+	})
+
+	Convey("Should return BadRequest for invalid offset parameter", t, func() {
+		qbMock := newQueryBuilderMock(nil, nil)
+		esMock := newElasticSearcherMock(nil, nil)
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?offset=b", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusBadRequest)
+		So(resp.Body.String(), ShouldContainSubstring, "Invalid offset parameter")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 0)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 0)
+	})
+
+	Convey("Should return BadRequest for negative offset parameter", t, func() {
+		qbMock := newQueryBuilderMock(nil, nil)
+		esMock := newElasticSearcherMock(nil, nil)
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?offset=-1", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusBadRequest)
+		So(resp.Body.String(), ShouldContainSubstring, "Invalid offset parameter")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 0)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 0)
+	})
+
+	Convey("Should return InternalError for errors returned from query builder", t, func() {
+		qbMock := newQueryBuilderMock(nil, errors.New("Something"))
+		esMock := newElasticSearcherMock(nil, nil)
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam, nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusInternalServerError)
+		So(resp.Body.String(), ShouldContainSubstring, "Failed to create search query")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 1)
+		So(qbMock.BuildSearchQueryCalls()[0].Q, ShouldResemble, validQueryParam)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 0)
+	})
+
+	Convey("Should return InternalError for errors returned from elastic search", t, func() {
+		qbMock := newQueryBuilderMock([]byte(validQueryDoc), nil)
+		esMock := newElasticSearcherMock(nil, errors.New("Something"))
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam, nil)
 		resp := httptest.NewRecorder()
@@ -140,7 +435,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(`{"dummy":"response"`), nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam, nil)
 		resp := httptest.NewRecorder()
@@ -161,7 +456,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock(nil, errors.New("Something"))
 
-		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam, nil)
 		resp := httptest.NewRecorder()
@@ -185,7 +480,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(`{"dummy":"response"}`), nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?q=a&raw=true", nil)
 		resp := httptest.NewRecorder()
@@ -207,7 +502,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam, nil)
 		resp := httptest.NewRecorder()
@@ -232,7 +527,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam+"&highlight=true", nil)
 		resp := httptest.NewRecorder()
@@ -257,7 +552,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?q="+validQueryParam+"&highlight=false", nil)
 		resp := httptest.NewRecorder()
@@ -282,7 +577,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+		searchHandler := LegacySearchHandlerFunc(qbMock, esMock, trMock)
 
 		req := httptest.NewRequest(
 			"GET",
@@ -317,7 +612,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 func TestCreateSearchIndexHandlerFunc(t *testing.T) {
 	Convey("Given a Search API that is pointing to the Site Wide version of Elastic Search", t, func() {
-		dpESClient := newDpElasticSearcherMock(nil)
+		dpESClient := newDpElasticSearcherMock(nil, nil)
 
 		searchAPI := &SearchAPI{dpESClient: dpESClient}
 
@@ -348,7 +643,7 @@ func TestCreateSearchIndexHandlerFunc(t *testing.T) {
 
 	Convey("Given a Search API that is pointing to the old version of Elastic Search", t, func() {
 		// The new ES client will return an error if the Search API config is pointing at the old version of ES
-		dpESClient := newDpElasticSearcherMock(errors.New("unexpected status code from api"))
+		dpESClient := newDpElasticSearcherMock(nil, errors.New("unexpected status code from api"))
 
 		searchAPI := &SearchAPI{dpESClient: dpESClient}
 
@@ -374,10 +669,13 @@ func newElasticSearcherMock(response []byte, err error) *ElasticSearcherMock {
 	}
 }
 
-func newDpElasticSearcherMock(err error) *DpElasticSearcherMock {
+func newDpElasticSearcherMock(response []byte, err error) *DpElasticSearcherMock {
 	return &DpElasticSearcherMock{
 		CreateIndexFunc: func(ctx context.Context, indexName string, indexSettings []byte) error {
 			return err
+		},
+		MultiSearchFunc: func(ctx context.Context, searches []client.Search) ([]byte, error) {
+			return response, err
 		},
 	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -85,7 +85,8 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 			Transport: awsSignerRT,
 		})
 		if esClientErr != nil {
-			log.Fatal(ctx, "Failed to create dp-elasticsearch client", esClientErr)
+			log.Error(ctx, "Failed to create dp-elasticsearch client", esClientErr)
+			return nil, err
 		}
 		transformerClient = transformer.New()
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -67,7 +67,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	deprecatedESClient := elasticsearch.New(cfg.ElasticSearchAPIURL, elasticHTTPClient, cfg.AWS.Region, cfg.AWS.Service)
 
 	// Initialise transformerClient
-	transformerClient = transformer.NewLegacy()
+	transformerClient = transformer.New(cfg.ElasticVersion710)
 
 	// Initialse AWS signer
 	if cfg.ElasticVersion710 {
@@ -88,7 +88,6 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 			log.Error(ctx, "Failed to create dp-elasticsearch client", esClientErr)
 			return nil, err
 		}
-		transformerClient = transformer.New()
 	}
 
 	// Initialise query builder

--- a/service/service.go
+++ b/service/service.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 
+	dpEs "github.com/ONSdigital/dp-elasticsearch/v3"
+	dpEsClient "github.com/ONSdigital/dp-elasticsearch/v3/client"
 	legacyESClient "github.com/ONSdigital/dp-elasticsearch/v3/client/elasticsearch/v2"
 	"github.com/ONSdigital/dp-net/v2/awsauth"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
@@ -25,7 +27,7 @@ type Service struct {
 	router              *mux.Router
 	server              HTTPServer
 	serviceList         *ExternalServiceList
-	transformer         *transformer.LegacyTransformer
+	transformer         api.ResponseTransformer
 }
 
 // SetServer sets the http server for a service
@@ -55,13 +57,20 @@ func (svc *Service) SetTransformer(transformerClient *transformer.LegacyTransfor
 
 // Run the service
 func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceList, buildTime, gitCommit, version string, svcErrors chan error) (svc *Service, err error) {
+	var esClientErr error
+	var esClient dpEsClient.Client
+	var transformerClient api.ResponseTransformer
+
 	elasticHTTPClient := dphttp.NewClient()
+	esClient = legacyESClient.NewClientWithHTTPClient(cfg.ElasticSearchAPIURL, elasticHTTPClient)
+	// Initialise deprecatedESClient
+	deprecatedESClient := elasticsearch.New(cfg.ElasticSearchAPIURL, elasticHTTPClient, cfg.AWS.Region, cfg.AWS.Service)
 
 	// Initialise transformerClient
-	transformerClient := transformer.NewLegacy()
+	transformerClient = transformer.NewLegacy()
 
 	// Initialse AWS signer
-	if cfg.SignElasticsearchRequests {
+	if cfg.ElasticVersion710 {
 		var awsSignerRT *awsauth.AwsSignerRoundTripper
 
 		awsSignerRT, err = awsauth.NewAWSSignerRoundTripper(cfg.AWS.Filename, cfg.AWS.Profile, cfg.AWS.Region, cfg.AWS.Service, awsauth.Options{TlsInsecureSkipVerify: cfg.AWS.TLSInsecureSkipVerify})
@@ -70,13 +79,16 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 			return nil, err
 		}
 
-		elasticHTTPClient = dphttp.NewClientWithTransport(awsSignerRT)
+		esClient, esClientErr = dpEs.NewClient(dpEsClient.Config{
+			ClientLib: dpEsClient.GoElasticV710,
+			Address:   cfg.ElasticSearchAPIURL,
+			Transport: awsSignerRT,
+		})
+		if esClientErr != nil {
+			log.Fatal(ctx, "Failed to create dp-elasticsearch client", esClientErr)
+		}
+		transformerClient = transformer.New()
 	}
-
-	dpESClient := legacyESClient.NewClientWithHTTPClient(cfg.ElasticSearchAPIURL, elasticHTTPClient)
-
-	// Initialise deprecatedESClient
-	deprecatedESClient := elasticsearch.New(cfg.ElasticSearchAPIURL, elasticHTTPClient, cfg.AWS.Region, cfg.AWS.Service)
 
 	// Initialise query builder
 	queryBuilder, err := query.NewQueryBuilder(cfg.ElasticVersion710)
@@ -95,7 +107,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		return nil, err
 	}
 
-	if regErr := registerCheckers(ctx, healthCheck, dpESClient); regErr != nil {
+	if regErr := registerCheckers(ctx, healthCheck, esClient); regErr != nil {
 		return nil, errors.Wrap(regErr, "unable to register checkers")
 	}
 
@@ -106,7 +118,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	healthCheck.Start(ctx)
 
 	// Create Search API
-	searchAPI, err := api.NewSearchAPI(router, dpESClient, deprecatedESClient, queryBuilder, transformerClient, permissions)
+	searchAPI, err := api.NewSearchAPI(router, esClient, deprecatedESClient, queryBuilder, transformerClient, permissions, cfg.ElasticVersion710)
 	if err != nil {
 		log.Fatal(ctx, "error initialising API", err)
 		return nil, err
@@ -186,7 +198,7 @@ func (svc *Service) Close(ctx context.Context) error {
 	return nil
 }
 
-func registerCheckers(ctx context.Context, hc HealthChecker, dpESClient *legacyESClient.Client) (err error) {
+func registerCheckers(ctx context.Context, hc HealthChecker, dpESClient dpEsClient.Client) (err error) {
 	if err = hc.AddCheck("Elasticsearch", dpESClient.Checker); err != nil {
 		log.Error(ctx, "error creating elasticsearch health check", err)
 		err = errors.New("Error(s) registering checkers for health check")

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ONSdigital/dp-search-api/api"
 	"github.com/ONSdigital/dp-search-api/models"
 	"github.com/pkg/errors"
 )
@@ -15,23 +16,20 @@ type LegacyTransformer struct {
 	higlightReplacer *strings.Replacer
 }
 
-// NewLegacy returns a new instance of Transformer
-func NewLegacy() *LegacyTransformer {
-	highlightReplacer := strings.NewReplacer("<em class=\"highlight\">", "", "</em>", "")
-	return &LegacyTransformer{
-		higlightReplacer: highlightReplacer,
-	}
-}
-
 // Transformer represents an instance of the ResponseTransformer interface for ES7x
 type Transformer struct {
 	higlightReplacer *strings.Replacer
 }
 
 // New returns a new instance of Transformer ES7x
-func New() *Transformer {
+func New(esVersion710 bool) api.ResponseTransformer {
 	highlightReplacer := strings.NewReplacer("<em class=\"highlight\">", "", "</em>", "")
-	return &Transformer{
+	if esVersion710 {
+		return &Transformer{
+			higlightReplacer: highlightReplacer,
+		}
+	}
+	return &LegacyTransformer{
 		higlightReplacer: highlightReplacer,
 	}
 }


### PR DESCRIPTION
### What

Search API is configurable to point to different Elasticsearch clients depending on the Elasticsearch version number.

This will enable us to transition over to Elasticsearch version 7.10 from 2.2 without breaking the application.

There will be a separate query builder and response transformer for each Elasticsearch version from previous tasks.

Default configuration must point to internal ES client until we move to ES 7.10 at which point we will use the flag to point to dp-elasticsearch client 7.10.

### How to review

This is based on the trello ticket: https://trello.com/c/Bd7Uydxe/955-extend-configurations-to-be-able-to-point-to-a-version-of-elasticsearch-client. 

Please have a look and see if the all acceptance criteria in the trello ticket is met. 

### Who can review

Anyone except me
