### PR TITLE
Fix multisearch query struct

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -51,7 +51,7 @@ type QueryParamValidator interface {
 
 // QueryBuilder provides methods for the search package
 type QueryBuilder interface {
-	BuildSearchQuery(ctx context.Context, q, contentTypes, sort string, topics []string, limit, offset int) ([]byte, error)
+	BuildSearchQuery(ctx context.Context, q, contentTypes, sort string, topics []string, limit, offset int, esVersion710 bool) ([]byte, error)
 }
 
 // ReleaseQueryBuilder provides an interface to build a search query for the Release content type

--- a/api/mocks.go
+++ b/api/mocks.go
@@ -369,7 +369,7 @@ var _ QueryBuilder = &QueryBuilderMock{}
 //
 // 		// make and configure a mocked QueryBuilder
 // 		mockedQueryBuilder := &QueryBuilderMock{
-// 			BuildSearchQueryFunc: func(ctx context.Context, q string, contentTypes string, sort string, topics []string, limit int, offset int) ([]byte, error) {
+// 			BuildSearchQueryFunc: func(ctx context.Context, q string, contentTypes string, sort string, topics []string, limit int, offset int, esVersion710 bool) ([]byte, error) {
 // 				panic("mock out the BuildSearchQuery method")
 // 			},
 // 		}
@@ -380,7 +380,7 @@ var _ QueryBuilder = &QueryBuilderMock{}
 // 	}
 type QueryBuilderMock struct {
 	// BuildSearchQueryFunc mocks the BuildSearchQuery method.
-	BuildSearchQueryFunc func(ctx context.Context, q string, contentTypes string, sort string, topics []string, limit int, offset int) ([]byte, error)
+	BuildSearchQueryFunc func(ctx context.Context, q string, contentTypes string, sort string, topics []string, limit int, offset int, esVersion710 bool) ([]byte, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -400,13 +400,15 @@ type QueryBuilderMock struct {
 			Limit int
 			// Offset is the offset argument value.
 			Offset int
+			// EsVersion710 is the esVersion710 argument value.
+			EsVersion710 bool
 		}
 	}
 	lockBuildSearchQuery sync.RWMutex
 }
 
 // BuildSearchQuery calls BuildSearchQueryFunc.
-func (mock *QueryBuilderMock) BuildSearchQuery(ctx context.Context, q string, contentTypes string, sort string, topics []string, limit int, offset int) ([]byte, error) {
+func (mock *QueryBuilderMock) BuildSearchQuery(ctx context.Context, q string, contentTypes string, sort string, topics []string, limit int, offset int, esVersion710 bool) ([]byte, error) {
 	if mock.BuildSearchQueryFunc == nil {
 		panic("QueryBuilderMock.BuildSearchQueryFunc: method is nil but QueryBuilder.BuildSearchQuery was just called")
 	}
@@ -418,6 +420,7 @@ func (mock *QueryBuilderMock) BuildSearchQuery(ctx context.Context, q string, co
 		Topics       []string
 		Limit        int
 		Offset       int
+		EsVersion710 bool
 	}{
 		Ctx:          ctx,
 		Q:            q,
@@ -426,11 +429,12 @@ func (mock *QueryBuilderMock) BuildSearchQuery(ctx context.Context, q string, co
 		Topics:       topics,
 		Limit:        limit,
 		Offset:       offset,
+		EsVersion710: esVersion710,
 	}
 	mock.lockBuildSearchQuery.Lock()
 	mock.calls.BuildSearchQuery = append(mock.calls.BuildSearchQuery, callInfo)
 	mock.lockBuildSearchQuery.Unlock()
-	return mock.BuildSearchQueryFunc(ctx, q, contentTypes, sort, topics, limit, offset)
+	return mock.BuildSearchQueryFunc(ctx, q, contentTypes, sort, topics, limit, offset, esVersion710)
 }
 
 // BuildSearchQueryCalls gets all the calls that were made to BuildSearchQuery.
@@ -444,6 +448,7 @@ func (mock *QueryBuilderMock) BuildSearchQueryCalls() []struct {
 	Topics       []string
 	Limit        int
 	Offset       int
+	EsVersion710 bool
 } {
 	var calls []struct {
 		Ctx          context.Context
@@ -453,6 +458,7 @@ func (mock *QueryBuilderMock) BuildSearchQueryCalls() []struct {
 		Topics       []string
 		Limit        int
 		Offset       int
+		EsVersion710 bool
 	}
 	mock.lockBuildSearchQuery.RLock()
 	calls = mock.calls.BuildSearchQuery

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.103.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-component-test v0.6.3
-	github.com/ONSdigital/dp-elasticsearch/v3 v3.0.0-alpha.3
+	github.com/ONSdigital/dp-elasticsearch/v3 v3.0.0-alpha.4
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-net/v2 v2.0.0
 	github.com/ONSdigital/dp-search-data-extractor v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/ONSdigital/dp-component-test v0.6.3/go.mod h1:CfpOujIEqZS5qON7sWn0LRy
 github.com/ONSdigital/dp-elasticsearch/v2 v2.3.0/go.mod h1:B+WXR1PRVgrU1/tS3UygATLVTnX+5Sp+M0w5i3LROac=
 github.com/ONSdigital/dp-elasticsearch/v3 v3.0.0-alpha.3 h1:AbCp4GAL1InSjo15Ffyk+kHoNHLBPKokzdRO86dwGFU=
 github.com/ONSdigital/dp-elasticsearch/v3 v3.0.0-alpha.3/go.mod h1:s00OAPfjfNf5u8z+RcNb8Wqgwo1+KtVgnawWtumOyWg=
+github.com/ONSdigital/dp-elasticsearch/v3 v3.0.0-alpha.4 h1:RJ5rgjoeDPXKbaQQNHx4YBKfdL4LqWBQ7e1I6g61cf0=
+github.com/ONSdigital/dp-elasticsearch/v3 v3.0.0-alpha.4/go.mod h1:s00OAPfjfNf5u8z+RcNb8Wqgwo1+KtVgnawWtumOyWg=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/models/elasticsearch.go
+++ b/models/elasticsearch.go
@@ -13,17 +13,26 @@ type EsResponse struct {
 	Took         int                    `json:"took"`
 	Hits         ESResponseHits         `json:"hits"`
 	Aggregations ESResponseAggregations `json:"aggregations"`
-	Suggest      []string               `json:"suggest"`
+	Suggest      Suggest                `json:"suggest"`
+}
+
+type Suggest struct {
+	SearchSuggest []SearchSuggest `json:"search_suggest"`
+}
+
+type SearchSuggest struct {
+	Text   string `json:"text"`
+	Offset int    `json:"offset"`
+	Length int    `json:"length"`
 }
 
 type ESResponseHits struct {
-	Total int
-	Hits  []ESResponseHit `json:"hits"`
+	Hits []ESResponseHit `json:"hits"`
 }
 
 type ESResponseHit struct {
-	Source    []ESSourceDocument `json:"_source"`
-	Highlight ESHighlight        `json:"highlight"`
+	Source    ESSourceDocument `json:"_source"`
+	Highlight ESHighlight      `json:"highlight"`
 }
 
 type ESResponseAggregations struct {
@@ -70,6 +79,6 @@ type SearchResponse struct {
 	Count               int                `json:"count"`
 	Took                int                `json:"took"`
 	Items               []ESSourceDocument `json:"items"`
-	Suggestions         []string           `json:"suggestions,omitempty"`
+	Suggestions         Suggest            `json:"suggestions,omitempty"`
 	AdditionSuggestions []string           `json:"additional_suggestions,omitempty"`
 }

--- a/query/releasesearch.go
+++ b/query/releasesearch.go
@@ -244,7 +244,7 @@ func (sb *ReleaseBuilder) BuildSearchQuery(_ context.Context, sr ReleaseSearchRe
 		return nil, fmt.Errorf("creation of search from template failed: %w", err)
 	}
 
-	formattedQuery, err := FormatMultiQuery(doc.Bytes())
+	formattedQuery, err := LegacyFormatMultiQuery(doc.Bytes())
 	if err != nil {
 		return nil, fmt.Errorf("formating of query for elasticsearch failed: %w", err)
 	}

--- a/query/search_test.go
+++ b/query/search_test.go
@@ -38,7 +38,7 @@ func TestBuildSearchQuery(t *testing.T) {
 		So(queryString, ShouldContainSubstring, "Size=2")
 		So(queryString, ShouldContainSubstring, "Types=[ta tb]")
 		So(queryString, ShouldContainSubstring, "SortBy=relevance")
-		So(queryString, ShouldContainSubstring, "AggregationField=type")
+		So(queryString, ShouldContainSubstring, "AggregationField=_type")
 		So(queryString, ShouldContainSubstring, "Highlight=true")
 		So(queryString, ShouldContainSubstring, "Now=20")
 	})

--- a/query/search_test.go
+++ b/query/search_test.go
@@ -11,7 +11,7 @@ import (
 func TestBuildSearchQuery(t *testing.T) {
 	Convey("Should return InternalError for invalid template", t, func() {
 		qb := createQueryBuilderForTemplate("dummy{{.Moo}}")
-		query, err := qb.BuildSearchQuery(context.Background(), "", "", "", nil, 2, 1)
+		query, err := qb.BuildSearchQuery(context.Background(), "", "", "", nil, 2, 1, false)
 
 		So(err, ShouldNotBeNil)
 		So(query, ShouldBeNil)
@@ -28,7 +28,7 @@ func TestBuildSearchQuery(t *testing.T) {
 			"Highlight={{.Highlight}};" +
 			"Now={{.Now}}")
 
-		query, err := qb.BuildSearchQuery(context.Background(), "a", "ta,tb", "relevance", []string{"test"}, 2, 1)
+		query, err := qb.BuildSearchQuery(context.Background(), "a", "ta,tb", "relevance", []string{"test"}, 2, 1, false)
 
 		So(err, ShouldBeNil)
 		So(query, ShouldNotBeNil)
@@ -38,7 +38,7 @@ func TestBuildSearchQuery(t *testing.T) {
 		So(queryString, ShouldContainSubstring, "Size=2")
 		So(queryString, ShouldContainSubstring, "Types=[ta tb]")
 		So(queryString, ShouldContainSubstring, "SortBy=relevance")
-		So(queryString, ShouldContainSubstring, "AggregationField=_type")
+		So(queryString, ShouldContainSubstring, "AggregationField=type")
 		So(queryString, ShouldContainSubstring, "Highlight=true")
 		So(queryString, ShouldContainSubstring, "Now=20")
 	})

--- a/query/templates/search/v710/contentHeader.tmpl
+++ b/query/templates/search/v710/contentHeader.tmpl
@@ -1,1 +1,1 @@
-{ /* content query */{{if .Index}} "index":"{{.Index}}"{{if .Types}},{{end}}{{else}} "index":"ons"{{if .Types}},{{end}} {{end}}{{if .Types}} "type" : [{{range $i,$e := .Types}}{{if $i}},{{end}}"{{.}}"{{end}}]{{end}} }
+{ /* content query */{{if .Index}} "index":"{{.Index}}"{{else}} "index":"ons"{{end}} }

--- a/query/templates/search/v710/countHeader.tmpl
+++ b/query/templates/search/v710/countHeader.tmpl
@@ -4,5 +4,4 @@
     {{else}}
         "index":"ons"
     {{end}}
-    {{if .Types}}, "type" : [{{range $i,$e := .Types}}{{if $i}},{{end}}"{{.}}"{{end}}]{{end}}
 }

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -220,8 +220,10 @@ func (t *Transformer) TransformSearchResponse(
 func (t *Transformer) transform(esresponse *models.EsResponses, highlight bool) models.SearchResponse {
 	var search7xResponse = models.SearchResponse{
 		Took:        esresponse.Responses[0].Took,
-		Items:       esresponse.Responses[0].Hits.Hits[0].Source,
 		Suggestions: esresponse.Responses[0].Suggest,
+	}
+	for i := 0; i < len(esresponse.Responses[0].Hits.Hits); i++ {
+		search7xResponse.Items = append(search7xResponse.Items, esresponse.Responses[0].Hits.Hits[i].Source)
 	}
 	return search7xResponse
 }

--- a/transformer/transformer_test.go
+++ b/transformer/transformer_test.go
@@ -223,7 +223,7 @@ func TestTransform(t *testing.T) {
 					So(len(transformedResponse.Items), ShouldEqual, 2)
 					So(transformedResponse.Items[0], ShouldResemble, expectedESDocument1)
 					So(transformedResponse.Items[1], ShouldResemble, expectedESDocument2)
-					So(transformedResponse.Suggestions[0], ShouldResemble, "testSuggestion")
+					So(transformedResponse.Suggestions.SearchSuggest[0].Text, ShouldResemble, "testSuggestion")
 				})
 			}
 		})
@@ -261,7 +261,12 @@ func prepareESMockResponse() models.EsResponses {
 	esDocuments := []models.ESSourceDocument{esDocument1, esDocument2}
 
 	hit := models.ESResponseHit{
-		Source:    esDocuments,
+		Source:    esDocuments[0],
+		Highlight: models.ESHighlight{},
+	}
+
+	hit2 := models.ESResponseHit{
+		Source:    esDocuments[1],
 		Highlight: models.ESHighlight{},
 	}
 
@@ -282,15 +287,19 @@ func prepareESMockResponse() models.EsResponses {
 	esResponse1 := models.EsResponse{
 		Took: 10,
 		Hits: models.ESResponseHits{
-			Total: 1,
 			Hits: []models.ESResponseHit{
 				hit,
+				hit2,
 			},
 		},
 		Aggregations: models.ESResponseAggregations{
 			Doccounts: esDoccount,
 		},
-		Suggest: []string{"testSuggestion"},
+		Suggest: models.Suggest{
+			SearchSuggest: []models.SearchSuggest{
+				{Text: "testSuggestion"},
+			},
+		},
 	}
 
 	// Preparing ES response array


### PR DESCRIPTION
### What

When trying to run the dp-search-api GET search api against elastic version 7.10, it is not getting the documents and resulting in 500 internal server error with a message as failed to perform multi search. 

So this pr is to basically fix the issue by restructuring the template according to the search object with Header and Query attributes. 

### How to review

This is done according to the trello ticket: https://trello.com/c/ahFHjF0R/1239-bug-template-use-me-for-new-bugs. 

So would be good to compare both and see if this makes sense. 

### Who can review

Anyone except me. 
