### PR TITLE
Remove unused flag SIGN_ELASTICSEARCH_REQUESTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ fmt:
 local:
 	export ELASTIC_SEARCH_URL=https://localhost:9200; \
 	export AWS_TLS_INSECURE_SKIP_VERIFY=true; \
-	export SIGN_ELASTICSEARCH_REQUESTS=true; \
 	export AWS_PROFILE=development; \
 	export AWS_FILENAME=$(HOME)/.aws/credentials; \
 	HUMAN_LOG=1 go run $(LDFLAGS) -race main.go

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,6 @@ type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	ElasticSearchAPIURL        string        `envconfig:"ELASTIC_SEARCH_URL"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
-	SignElasticsearchRequests  bool          `envconfig:"SIGN_ELASTICSEARCH_REQUESTS"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
@@ -43,7 +42,6 @@ func Get() (*Config, error) {
 		BindAddr:                   ":23900",
 		ElasticSearchAPIURL:        "http://localhost:9200",
 		GracefulShutdownTimeout:    5 * time.Second,
-		SignElasticsearchRequests:  false,
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		ZebedeeURL:                 "http://localhost:8082",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,7 +26,6 @@ func TestSpec(t *testing.T) {
 				So(cfg.ElasticSearchAPIURL, ShouldEqual, "http://localhost:9200")
 				So(cfg.ElasticVersion710, ShouldEqual, false)
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
-				So(cfg.SignElasticsearchRequests, ShouldEqual, false)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 			})


### PR DESCRIPTION
### What

Remove unused flag SIGN_ELASTICSEARCH_REQUESTS

### How to review

This is based on the comment done for the release: https://github.com/ONSdigital/dp-search-api/pull/118

### Who can review

Anyone except me
