### PR TITLE
add es710 bool in response

### DIFF
--- a/models/elasticsearch.go
+++ b/models/elasticsearch.go
@@ -97,6 +97,7 @@ type ESHighlight struct {
 // ********************************************************
 
 type SearchResponse struct {
+	ES_710              bool               `json:"es_710"`
 	Took                int                `json:"took"`
 	ContentTypes        []ContentType      `json:"content_types"`
 	Items               []ESSourceDocument `json:"items"`

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -202,6 +202,7 @@ func (t *Transformer) TransformSearchResponse(
 	}
 
 	sr := t.transform(&esResponse, highlight)
+	sr.ES_710 = true
 
 	needAdditionalSuggestions := numberOfSearchTerms(query)
 	if needAdditionalSuggestions > 1 {


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- The `ES_710` bool helps the search controller to identify what type of data is coming to then map the data accordingly for rendering

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone