### PR TITLE
Add content type as filter combined with topic

### DIFF
--- a/query/query_test.go
+++ b/query/query_test.go
@@ -47,6 +47,7 @@ func TestNewQueryBuilder(t *testing.T) {
 		So(builderObject.searchTemplates.DefinedTemplates(), ShouldContainSubstring, "sortByFirstLetter.tmpl")
 		So(builderObject.searchTemplates.DefinedTemplates(), ShouldContainSubstring, "topicFilters.tmpl")
 		So(builderObject.searchTemplates.DefinedTemplates(), ShouldContainSubstring, "canonicalFilters.tmpl")
+		So(builderObject.searchTemplates.DefinedTemplates(), ShouldContainSubstring, "contentTypeFilter.tmpl")
 		So(err, ShouldBeNil)
 	})
 }

--- a/query/search.go
+++ b/query/search.go
@@ -76,6 +76,7 @@ func SetupV710Search() (*template.Template, error) {
 		"templates/search/v710/contentHeader.tmpl",
 		"templates/search/v710/countHeader.tmpl",
 		"templates/search/v710/countQuery.tmpl",
+		"templates/search/v710/contentTypeFilter.tmpl",
 		"templates/search/v710/topicCountHeader.tmpl",
 		"templates/search/v710/topicCountQuery.tmpl",
 		"templates/search/v710/coreQuery.tmpl",

--- a/query/templates/search/v710/contentFilters.tmpl
+++ b/query/templates/search/v710/contentFilters.tmpl
@@ -1,14 +1,20 @@
-{{ if or .URIPrefix .TopicWildcard}}
 ,
 "filter" : [
-{{if or .URIPrefix .TopicWildcard}}
-  { "bool": { "should": [
-
-  {{ template "contentFilterOnURIPrefix.tmpl" . }}
-  {{ template "contentFilterOnTopicWildcard.tmpl" . }}
-
-    ]}
-  }
- {{end}}
+{
+	"bool": {
+		"must": [
+		   { "bool": { "should": [
+		       {{ template "contentTypeFilter.tmpl" . }}
+		   ]}}
+           {{if or .URIPrefix .TopicWildcard .Topic}}
+           ,{ "bool": { "should": [
+                                  {{ template "topicFilters.tmpl" . }}
+                                  {{ template "contentFilterOnURIPrefix.tmpl" . }}
+                                  {{ template "contentFilterOnTopicWildcard.tmpl" . }}
+                                  ]}
+          }
+         {{end}}
+          ]
+	}
+}
 ]
-{{end}}

--- a/query/templates/search/v710/contentFilters.tmpl
+++ b/query/templates/search/v710/contentFilters.tmpl
@@ -1,20 +1,27 @@
 ,
 "filter" : [
 {
-	"bool": {
-		"must": [
-		   { "bool": { "should": [
-		       {{ template "contentTypeFilter.tmpl" . }}
-		   ]}}
-           {{if or .URIPrefix .TopicWildcard .Topic}}
-           ,{ "bool": { "should": [
-                                  {{ template "topicFilters.tmpl" . }}
-                                  {{ template "contentFilterOnURIPrefix.tmpl" . }}
-                                  {{ template "contentFilterOnTopicWildcard.tmpl" . }}
-                                  ]}
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {{ template "contentTypeFilter.tmpl". }}
+            ]
           }
-         {{end}}
-          ]
-	}
-}
+        }
+        {{ if or.URIPrefix.TopicWildcard.Topic }}
+        , {
+          "bool": {
+            "should": [
+              {{ template "topicFilters.tmpl". }}
+              {{ template "contentFilterOnURIPrefix.tmpl". }}
+              {{ template "contentFilterOnTopicWildcard.tmpl". }}
+            ]
+          }
+        }
+        {{ end }}
+      ]
+    }
+  }
 ]

--- a/query/templates/search/v710/contentFilters.tmpl
+++ b/query/templates/search/v710/contentFilters.tmpl
@@ -10,7 +10,7 @@
             ]
           }
         }
-        {{ if or.URIPrefix.TopicWildcard.Topic }}
+        {{if or .URIPrefix .TopicWildcard .Topic}}
         , {
           "bool": {
             "should": [

--- a/query/templates/search/v710/contentQuery.tmpl
+++ b/query/templates/search/v710/contentQuery.tmpl
@@ -6,9 +6,6 @@
  "size" : {{.Size}},
  "query" : {
      "bool" : {
-          {{- if .Topic}}
-             {{template "topicFilters.tmpl" .}}
-          {{- else}}
              "must" : {
                   {{- if .Term}}
                       {{- template "weightedQuery.tmpl" .}}
@@ -17,7 +14,6 @@
                    {{- end}}
               }
              {{template "contentFilters.tmpl" .}}
-         {{- end}}
          }
     },
  "suggest":{

--- a/query/templates/search/v710/contentTypeFilter.tmpl
+++ b/query/templates/search/v710/contentTypeFilter.tmpl
@@ -1,0 +1,8 @@
+{{range $i,$e := .Types}}
+{{if $i}},{{end}}
+{
+   "match":{
+      "type": "{{.}}"
+   }
+}
+{{end}}

--- a/query/templates/search/v710/topicFilters.tmpl
+++ b/query/templates/search/v710/topicFilters.tmpl
@@ -1,4 +1,4 @@
-"should":[
+{{/* topic query */}}
       {
          "match":{
              "topic" :
@@ -6,4 +6,3 @@
          }
       }
       {{ template "canonicalFilters.tmpl" . }}
-   ]


### PR DESCRIPTION
### What

Old Elasticsearch(2.2) included content_type in the multi search body header. From the latest Elaticsearch(7.10) , it does not support type in its header. So the query should be modified to use the content type as a filter instead for the new version of elasticsearch. 

### How to review

Check if the changes make sense

### Who can review

Anyone except me
