### PR TITLE
Remove service auth token from config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,6 @@ type Config struct {
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
-	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN"             json:"-"`
 	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
 }
 
@@ -44,7 +43,6 @@ func Get() (*Config, error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
-		ServiceAuthToken:           "",
 		ZebedeeURL:                 "http://localhost:8082",
 	}
 


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The SERVICE_AUTH_TOKEN has ben removed from the config as it is not used in the code.

NB. Although there IS a service auth token, which is used in the bulk indexer, that is not the one that's defined in config.go but instead it's defined here:
- in cmd/reindex/local.go (if running the bulk indexer locally)
- in cmd/reindex/aws.go (if running it in either sandbox or prod)

# How to review
<!--- Describe in detail how you tested your changes. -->
The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

The linter can be run using this command: make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
