### PR TITLE
Bug Fix

### DIFF
--- a/elasticsearch/search-index-settings.json
+++ b/elasticsearch/search-index-settings.json
@@ -272,9 +272,6 @@
         "type":"text",
         "analyzer":"ons_standard"
       },
-      "provisional_date":{
-        "type":"date"
-      },
       "survey":{
         "type":"keyword"
       },

--- a/service/service.go
+++ b/service/service.go
@@ -75,6 +75,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		esConfig := dpEsClient.Config{
 			ClientLib: dpEsClient.GoElasticV710,
 			Address:   cfg.ElasticSearchAPIURL,
+			Transport: dphttp.DefaultTransport,
 		}
 
 		if cfg.AWS.Signer {
@@ -87,8 +88,6 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 			}
 
 			esConfig.Transport = awsSignerRT
-		} else {
-			esConfig.Transport = dphttp.DefaultTransport
 		}
 
 		esClient, esClientErr = dpEs.NewClient(esConfig)

--- a/service/service.go
+++ b/service/service.go
@@ -87,6 +87,8 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 			}
 
 			esConfig.Transport = awsSignerRT
+		} else {
+			esConfig.Transport = dphttp.DefaultTransport
 		}
 
 		esClient, esClientErr = dpEs.NewClient(esConfig)


### PR DESCRIPTION
### What
Fix 2 small bugs:
- Remove provisional_date from the ElasticSearch mapping as it's not needed (and is not a date but a string)
- If an AWS signer is not used to connect to ElasticSearch (in local development for example), then use the DefaultTransport


### How to review

Review code and ensure all tests are passing

### Who can review

Anyone
