### PR TITLE
Fix alternate suggestions from elasticsearch

### DIFF
--- a/api/search.go
+++ b/api/search.go
@@ -66,7 +66,7 @@ func SearchHandlerFunc(queryBuilder QueryBuilder, elasticSearchClient DpElasticS
 		params := req.URL.Query()
 
 		q := params.Get("q")
-		q = sanitiseDoubleQuotes(q)
+		sanitisedQuery := sanitiseDoubleQuotes(q)
 		sort := paramGet(params, "sort", "relevance")
 
 		highlight := paramGetBool(params, "highlight", true)
@@ -116,9 +116,9 @@ func SearchHandlerFunc(queryBuilder QueryBuilder, elasticSearchClient DpElasticS
 
 		typesParam := paramGet(params, "content_type", defaultContentTypes)
 
-		formattedQuery, err := queryBuilder.BuildSearchQuery(ctx, q, typesParam, sort, topicSlice, limit, offset, true)
+		formattedQuery, err := queryBuilder.BuildSearchQuery(ctx, sanitisedQuery, typesParam, sort, topicSlice, limit, offset, true)
 		if err != nil {
-			log.Error(ctx, "creation of search query failed", err, log.Data{"q": q, "sort": sort, "limit": limit, "offset": offset})
+			log.Error(ctx, "creation of search query failed", err, log.Data{"q": sanitisedQuery, "sort": sort, "limit": limit, "offset": offset})
 			http.Error(w, "Failed to create search query", http.StatusInternalServerError)
 			return
 		}

--- a/transformer/testdata/zero_search_expected.json
+++ b/transformer/testdata/zero_search_expected.json
@@ -19,6 +19,6 @@
     "additional_suggestions": [
         "test",
         "query",
-        "\"with quote marks\""
+        "with quote marks"
     ]
 }

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -176,7 +176,7 @@ func buildAdditionalSuggestionList(query string) []string {
 
 	queryTerms := []string{}
 	for _, match := range regex.FindAllStringSubmatch(query, -1) {
-		queryTerms = append(queryTerms, match[0])
+		queryTerms = append(queryTerms, strings.Trim(match[0], "\""))
 	}
 	return queryTerms
 }

--- a/transformer/transformer_test.go
+++ b/transformer/transformer_test.go
@@ -108,7 +108,7 @@ func TestLegacyBuildAdditionalSuggestionsList(t *testing.T) {
 			So(query3, ShouldHaveLength, 3)
 			So(query3[0], ShouldEqual, "test")
 			So(query3[1], ShouldEqual, "query")
-			So(query3[2], ShouldEqual, "\"with quote marks\"")
+			So(query3[2], ShouldEqual, "with quote marks")
 		})
 	})
 }


### PR DESCRIPTION
### What

Fix alternate suggestion from elasticsearch. The alternate suggestions from elasticsearch where not correct when you search for a word say ```economy "test test2"```. This pr fixes this to have the same behaviour as es2.2 

New behaviour in ES 7.10 from ES 2.2 - handles alternative suggestions by removing duplicate terms and single query term in quotes will now split the terms in quotes and add to the list of alternative terms (only when there is a single term)

### How to review

Please check if the changes make sense. 

### Who can review

Anyone except me
