### PR TITLE
Additional suggestions - handle duplicate query terms and quoted search term

### DIFF
--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -190,7 +190,7 @@ func buildAdditionalSuggestionList(query string) []string {
 	if len(queryTerms) == 1 && strings.Contains(queryTerms[0], " ") {
 		terms := strings.Fields(queryTerms[0])
 
-		//reset queryTerms field
+		// reset queryTerms field
 		queryTerms = nil
 		for i := range terms {
 			if existingQueryTerms[terms[i]] {

--- a/transformer/transformer_test.go
+++ b/transformer/transformer_test.go
@@ -109,6 +109,28 @@ func TestLegacyBuildAdditionalSuggestionsList(t *testing.T) {
 			So(query3[0], ShouldEqual, "test")
 			So(query3[1], ShouldEqual, "query")
 			So(query3[2], ShouldEqual, "with quote marks")
+
+			query4 := buildAdditionalSuggestionList("multiple multiple terms")
+			So(query4, ShouldHaveLength, 2)
+			So(query4[0], ShouldEqual, "multiple")
+			So(query4[1], ShouldEqual, "terms")
+
+			query5 := buildAdditionalSuggestionList("\"with quote marks only\"")
+			So(query5, ShouldHaveLength, 4)
+			So(query5[0], ShouldEqual, "with")
+			So(query5[1], ShouldEqual, "quote")
+			So(query5[2], ShouldEqual, "marks")
+			So(query5[3], ShouldEqual, "only")
+
+			query6 := buildAdditionalSuggestionList("\"with quote marks in terms and duplicate terms\"")
+			So(query6, ShouldHaveLength, 7)
+			So(query6[0], ShouldEqual, "with")
+			So(query6[1], ShouldEqual, "quote")
+			So(query6[2], ShouldEqual, "marks")
+			So(query6[3], ShouldEqual, "in")
+			So(query6[4], ShouldEqual, "terms")
+			So(query6[5], ShouldEqual, "and")
+			So(query6[6], ShouldEqual, "duplicate")
 		})
 	})
 }


### PR DESCRIPTION
### What

For additional suggestions:
- Duplicate terms in search query parameter now only returns a single term instead of multiple in additional suggestions
- When there is a single quoted search term, the additional suggestions will extract the terms within the quotes to be usd by additional suggestions

### How to review

Check changes make sense

### Who can review

Anyone
