### PR TITLE
Reduce number of replicas from 2 to 1

### DIFF
--- a/elasticsearch/search-index-settings.json
+++ b/elasticsearch/search-index-settings.json
@@ -2,7 +2,7 @@
   "settings":{
     "index":{
       "number_of_shards":5,
-      "number_of_replicas":2
+      "number_of_replicas":1
     },
     "analysis":{
       "analyzer":{


### PR DESCRIPTION
### What

See title; the environments only contain 2 nodes in the Elasticsearch cluster and hence any new index cannot have more than replicas >= number of available nodes

We could increase the number of nodes but this will likely have a knock on effect on performance.

### How to review

Check the elasticsearch index settings have been updated to set the number of replicas to 1

### Who can review

Anyone
