### PR TITLE
Fix filter query attrbute to have the correct topics field

### DIFF
--- a/query/templates/search/v710/topicFilters.tmpl
+++ b/query/templates/search/v710/topicFilters.tmpl
@@ -1,7 +1,7 @@
 {{/* topic query */}}
       {
          "match":{
-             "topic" :
+             "topics" :
                     "{{ .ConcatTopic }}"
          }
       }


### PR DESCRIPTION
### What

Fix filtering of the subtopics by correcting the attribute name. basically we have the subtopics list stored in ES7.10  as topics instead of topic as these are a slice of strings. 

### How to review

Please check if the changes make sense. Tested against sandbox. 

### Who can review

Anyone except me.
