### PR TITLE
Bug/fix sub topics filtering

### DIFF
--- a/query/query_test.go
+++ b/query/query_test.go
@@ -47,6 +47,7 @@ func TestNewQueryBuilder(t *testing.T) {
 		So(builderObject.searchTemplates.DefinedTemplates(), ShouldContainSubstring, "sortByFirstLetter.tmpl")
 		So(builderObject.searchTemplates.DefinedTemplates(), ShouldContainSubstring, "topicFilters.tmpl")
 		So(builderObject.searchTemplates.DefinedTemplates(), ShouldContainSubstring, "canonicalFilters.tmpl")
+		So(builderObject.searchTemplates.DefinedTemplates(), ShouldContainSubstring, "subTopicsFilters.tmpl")
 		So(builderObject.searchTemplates.DefinedTemplates(), ShouldContainSubstring, "contentTypeFilter.tmpl")
 		So(err, ShouldBeNil)
 	})

--- a/query/search.go
+++ b/query/search.go
@@ -135,7 +135,3 @@ func (sb *Builder) BuildSearchQuery(ctx context.Context, q, contentTypes, sort s
 
 	return formattedQuery, nil
 }
-
-func (sr searchRequest) ConcatTopic() string {
-	return strings.Join(sr.Topic, ",")
-}

--- a/query/search.go
+++ b/query/search.go
@@ -87,6 +87,7 @@ func SetupV710Search() (*template.Template, error) {
 		"templates/search/v710/sortByTitle.tmpl",
 		"templates/search/v710/topicFilters.tmpl",
 		"templates/search/v710/canonicalFilters.tmpl",
+		"templates/search/v710/subTopicsFilters.tmpl",
 		"templates/search/v710/sortByRelevance.tmpl",
 		"templates/search/v710/sortByReleaseDate.tmpl",
 		"templates/search/v710/sortByReleaseDateAsc.tmpl",

--- a/query/templates/search/v710/canonicalFilters.tmpl
+++ b/query/templates/search/v710/canonicalFilters.tmpl
@@ -1,7 +1,8 @@
 {{range $i,$e := .Topic}}
-,{
+ {{if $i}},{{end}}
+ {
    "match":{
       "canonical_topic": "{{.}}"
    }
-}
+ }
 {{end}}

--- a/query/templates/search/v710/subTopicsFilters.tmpl
+++ b/query/templates/search/v710/subTopicsFilters.tmpl
@@ -1,0 +1,7 @@
+{{range $i,$e := .Topic}}
+,{
+   "match":{
+      "topics": "{{.}}"
+   }
+}
+{{end}}

--- a/query/templates/search/v710/topicFilters.tmpl
+++ b/query/templates/search/v710/topicFilters.tmpl
@@ -1,8 +1,3 @@
 {{/* topic query */}}
-      {
-         "match":{
-             "topics" :
-                    "{{ .ConcatTopic }}"
-         }
-      }
       {{ template "canonicalFilters.tmpl" . }}
+      {{ template "subTopicsFilters.tmpl" . }}


### PR DESCRIPTION
### What

Fix filtering by canonical topic and subtopics. For example if a doc A contains canonical topic as   ```"123"``` and doc B has canonical topic empty , but subtopics as ```["123", "456"]```. Then both doc A and b should be returned. 

### How to review

Please check if the changes make sense. 

### Who can review

Anyone except me. 
