### PR TITLE
Update documentation and default elasticsearch url should point to port 11200 for ES 7.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A Go application microservice to provide query functionality on the ONS Website
 
 Set up dependencies locally as follows:
 
-* In dp-compose run `docker-compose up -d` to run both versions of ElasticSearch
-* Elasticsearch 7.10 will run on port 11200
+* In [dp-compose](https://github.com/ONSdigital/dp-compose) run `docker-compose up -d` to run ElasticSearch 7.10
+	* dp-compose will run Elasticsearch 7.10 on port 11200 to not conflict with ES 2.2 running on port 9200
 * If using the POST /search endpoint then authorisation for this requires running Vault and Zebedee as follows:
 * In any directory run `vault server -dev` as Zebedee has a dependency on Vault
 * In the zebedee directory run `./run.sh` to run Zebedee
@@ -18,7 +18,6 @@ Then run `make debug`
 
 ### Dependencies
 
-For endpoints that require the Site Wide ElasticSearch (version 7.10.0):
 * Requires ElasticSearch running on port 11200
 * Requires Zebedee running on port 8082
 * No further dependencies other than those defined in `go.mod`

--- a/README.md
+++ b/README.md
@@ -6,19 +6,10 @@ A Go application microservice to provide query functionality on the ONS Website
 
 ### Getting started
 
-There are now 2 versions of ElasticSearch being used by this service:
-* 2.4.2 (the old/existing ElasticSearch)
-* 7.10.0 (Site Wide ElasticSearch)
-
-Version 2.4.2 is required by all endpoints except for the POST /search endpoint, which uses 7.10
-
 Set up dependencies locally as follows:
 
 * In dp-compose run `docker-compose up -d` to run both versions of ElasticSearch
-* NB. Version 2.4.2 will run on port 9200, version 7.10 will run on port 11200
-* If using endpoints that require version 2.4.2, there are no more dependencies to set up.
-* NB. What endpoints are available depends on what port the ELASTIC_SEARCH_URL points to. By default, it points to port 9200, so to point to 11200 (if required) run the following:
-* `export ELASTIC_SEARCH_URL="http://localhost:11200"`
+* Elasticsearch 7.10 will run on port 11200
 * If using the POST /search endpoint then authorisation for this requires running Vault and Zebedee as follows:
 * In any directory run `vault server -dev` as Zebedee has a dependency on Vault
 * In the zebedee directory run `./run.sh` to run Zebedee
@@ -26,10 +17,6 @@ Set up dependencies locally as follows:
 Then run `make debug`
 
 ### Dependencies
-
-For endpoints that require the old/existing ElasticSearch (version 2.4.2):
-* Requires ElasticSearch running on port 9200
-* No further dependencies other than those defined in `go.mod`
 
 For endpoints that require the Site Wide ElasticSearch (version 7.10.0):
 * Requires ElasticSearch running on port 11200
@@ -50,8 +37,7 @@ environment variables, or with a link to a configuration guide.
 | AWS_SIGNER                   | false                    | The AWS signer flag will determine if requests to Elasticsearch contain round tripper for signing requests
 | AWS_TLS_INSECURE_SKIP_VERIFY | false                    | This should never be set to true, as it disables SSL certificate verification. Used only for development
 | BIND_ADDR                    | :23900                   | The host and port to bind to
-| ELASTIC_SEARCH_URL	       | "http://localhost:9200"  | Http url of the ElasticSearch server. For Site Wide ElasticSearch this needs to be set to "http://localhost:11200".
-| ELASTIC_VERSION_710          | false                    | Boolean flag to switch on the elastic version 7.10. By default this will point to the legacy ES version which is 2.2
+| ELASTIC_SEARCH_URL	       | "http://localhost:11200" | Http url of the ElasticSearch server
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                       | The graceful shutdown timeout in seconds (`time.Duration` format)
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s                      | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
 | HEALTHCHECK_INTERVAL         | 30s                      | Time between self-healthchecks (`time.Duration` format)
@@ -67,7 +53,7 @@ environment variables, or with a link to a configuration guide.
 
 #### Connecting
 
-To connect to managed Elasticsearch cluster in AWS, you will want to port forward 9200 to the domain endpoint. Using the dp tool, one can do this like so:
+To connect to managed Elasticsearch cluster in AWS, you will want to port forward 11200 to the domain endpoint. Using the dp tool, one can do this like so:
 
 ```
   dp ssh develop <ip of aws box> -p 9200:<elasticsearch cluster domain endpoint e.g. "<unique identifier>" + "eu-west-1.es.amazonaws.com:443"
@@ -87,7 +73,7 @@ The Bulk Indexer creates an Elastic Search 7.10 index with the alias "ons". It l
 
 ###### Prerequisites
 
-* Requires ElasticSearch 7.10 running on port 9200 (NOT 11200)
+* Requires ElasticSearch 7.10 running on port 11200
 * Requires Zebedee running on port 8082 (and this has a dependency on vault)
 * Requires the Dataset API running on port 22000
 * Requires a local service auth token value to be put in line 35 of cmd/reindex/local.go
@@ -102,7 +88,7 @@ NB. The Dataset API requires a mongo database named 'datasets', which must conta
 
 The Dataset API also requires this environment variable to be set to true: DISABLE_GRAPH_DB_DEPENDENCY
 
-Please make sure your elasticsearch server is running locally on localhost:9200 and version of the server is 7.10, which is the current supported version.
+Please make sure your elasticsearch server is running locally on localhost:11200 and version of the server is 7.10, which is the current supported version.
 
 ###### Steps
 

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ func Get() (*Config, error) {
 
 	cfg = &Config{
 		BindAddr:                   ":23900",
-		ElasticSearchAPIURL:        "http://localhost:9200",
+		ElasticSearchAPIURL:        "http://localhost:11200",
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		HealthCheckInterval:        30 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.AWS.Service, ShouldEqual, "es")
 				So(cfg.AWS.TLSInsecureSkipVerify, ShouldEqual, false)
 				So(cfg.BindAddr, ShouldEqual, ":23900")
-				So(cfg.ElasticSearchAPIURL, ShouldEqual, "http://localhost:9200")
+				So(cfg.ElasticSearchAPIURL, ShouldEqual, "http://localhost:11200")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)


### PR DESCRIPTION
### What

See title

### How to review

Check changes make sense

### Who can review

Anyone
