### PR TITLE
Handle scenario for different metadata received from Dataset API

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -226,7 +226,13 @@ func transformZebedeeDoc(extractedChan chan Document, transformedChan chan<- Doc
 
 func transformMetadataDoc(metadataChan chan dataset.Metadata, transformedChan chan<- Document, wg *sync.WaitGroup) {
 	for metadata := range metadataChan {
-		uri := metadata.DatasetLinks.LatestVersion.URL
+		var uri string
+		if len(metadata.DatasetLinks.LatestVersion.URL) > 0 {
+			uri = metadata.DatasetLinks.LatestVersion.URL
+		} else {
+			uri = metadata.DatasetDetails.Links.Version.URL
+		}
+
 		parsedURI, err := url.Parse(uri)
 		if err != nil {
 			log.Fatalf("error occured while parsing url: %v", err)


### PR DESCRIPTION
### What

Cantabular datasets have "latest_version" field set in "dataset_links" object, while CMD datasets have "version" field set in "links" object when calling the metadata endpoint on the dataset.

### How to review

Check changes make sense and run against Sandbox environment to see this fixes CMD datasets found in search, e.g. linking to dataset landing page now works

### Who can review

Anyone
