### PR TITLE
Handle scenario for different metadata received from Dataset API

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -229,8 +229,10 @@ func transformMetadataDoc(metadataChan chan dataset.Metadata, transformedChan ch
 		var uri string
 		if len(metadata.DatasetLinks.LatestVersion.URL) > 0 {
 			uri = metadata.DatasetLinks.LatestVersion.URL
-		} else {
+		} else if len(metadata.DatasetDetails.Links.Version.URL) > 0 {
 			uri = metadata.DatasetDetails.Links.Version.URL
+		} else {
+			uri = metadata.Version.Links.Version.URL
 		}
 
 		parsedURI, err := url.Parse(uri)


### PR DESCRIPTION
### What

Cantabular datasets have "latest_version" field set in "dataset_links" object, while CMD datasets have "version" field set in "links" object when calling the metadata endpoint on the dataset.

### How to review

Check changes make sense and run against Sandbox environment to see this fixes CMD datasets found in search, e.g. linking to dataset landing page now works

### Who can review

Anyone except me