### PR TITLE
exported Header struct, as required by consumers to use headers

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -128,7 +128,7 @@ type ResponseInfo struct {
 
 // callSearchAPI calls the Search API endpoint given by path for the provided REST method, request headers, and body payload.
 // It returns the response body and any error that occurred.
-func (cli *Client) callSearchAPI(ctx context.Context, path, method string, headers map[header][]string, payload []byte) (*ResponseInfo, apiError.Error) {
+func (cli *Client) callSearchAPI(ctx context.Context, path, method string, headers http.Header, payload []byte) (*ResponseInfo, apiError.Error) {
 	URL, err := url.Parse(path)
 	if err != nil {
 		return nil, apiError.StatusError{
@@ -194,7 +194,6 @@ func (cli *Client) callSearchAPI(ctx context.Context, path, method string, heade
 			Code: resp.StatusCode,
 		}
 	}
-
 	return respInfo, nil
 }
 

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -137,8 +137,9 @@ func TestCreateIndex(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	headers := make(map[header][]string)
-	headers[Authorisation] = []string{"Bearer authorised-user"}
+	headers := http.Header{
+		Authorization: {"Bearer authorised-user"},
+	}
 
 	Convey("Given request is authorised to create a new search index", t, func() {
 		body, err := json.Marshal(createIndexResponse)
@@ -169,7 +170,7 @@ func TestCreateIndex(t *testing.T) {
 						So(doCalls, ShouldHaveLength, 1)
 						So(doCalls[0].Req.Method, ShouldEqual, "POST")
 						So(doCalls[0].Req.URL.Path, ShouldEqual, "/search")
-						So(doCalls[0].Req.Header["Authorisation"], ShouldResemble, []string{"Bearer authorised-user"})
+						So(doCalls[0].Req.Header["Authorization"], ShouldResemble, []string{"Bearer authorised-user"})
 					})
 				})
 			})
@@ -196,7 +197,7 @@ func TestCreateIndex(t *testing.T) {
 						So(doCalls, ShouldHaveLength, 1)
 						So(doCalls[0].Req.Method, ShouldEqual, "POST")
 						So(doCalls[0].Req.URL.Path, ShouldEqual, "/search")
-						So(doCalls[0].Req.Header["Authorisation"], ShouldBeEmpty)
+						So(doCalls[0].Req.Header["Authorization"], ShouldBeEmpty)
 					})
 				})
 			})
@@ -222,7 +223,7 @@ func TestCreateIndex(t *testing.T) {
 						So(doCalls, ShouldHaveLength, 1)
 						So(doCalls[0].Req.Method, ShouldEqual, "POST")
 						So(doCalls[0].Req.URL.Path, ShouldEqual, "/search")
-						So(doCalls[0].Req.Header["Authorisation"], ShouldResemble, []string{"Bearer authorised-user"})
+						So(doCalls[0].Req.Header["Authorization"], ShouldResemble, []string{"Bearer authorised-user"})
 					})
 				})
 			})
@@ -266,7 +267,7 @@ func TestGetSearch(t *testing.T) {
 						So(doCalls[0].Req.Method, ShouldEqual, "GET")
 						So(doCalls[0].Req.URL.Path, ShouldEqual, "/search")
 						So(doCalls[0].Req.URL.Query().Get("q"), ShouldEqual, "census")
-						So(doCalls[0].Req.Header["Authorisation"], ShouldBeEmpty)
+						So(doCalls[0].Req.Header["Authorization"], ShouldBeEmpty)
 					})
 				})
 			})
@@ -310,7 +311,7 @@ func TestGetReleaseCalendar(t *testing.T) {
 						So(doCalls[0].Req.Method, ShouldEqual, "GET")
 						So(doCalls[0].Req.URL.Path, ShouldEqual, "/search/releases")
 						So(doCalls[0].Req.URL.Query().Get("q"), ShouldEqual, "census")
-						So(doCalls[0].Req.Header["Authorisation"], ShouldBeEmpty)
+						So(doCalls[0].Req.Header["Authorization"], ShouldBeEmpty)
 					})
 				})
 			})

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -5,23 +5,22 @@ import (
 	"net/url"
 )
 
-type header string
-
 const (
 	// List of available headers
-	Authorisation header = "Authorisation"
+	Authorization string = "Authorization"
+	CollectionID  string = "Collection-Id"
 )
 
 // Options is a struct containing for customised options for the API client
 type Options struct {
-	Headers map[header][]string
+	Headers http.Header
 	Query   url.Values
 }
 
-func setHeaders(req *http.Request, headers map[header][]string) {
-	for h := range headers {
-		for i := range headers[h] {
-			req.Header.Add(string(h), headers[h][i])
+func setHeaders(req *http.Request, headers http.Header) {
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
 		}
 	}
 }


### PR DESCRIPTION
### What

https://github.com/ONSdigital/dp-frontend-search-controller/pull/184 caused regression as it doesn't pass Authorization header.  This is only relevant from the publishing subnet, thus was not caught by my testing.

Currently unable to use the sdk package to pass headers without exposing the Header type.

### How to review

[Required for this PR](https://github.com/ONSdigital/dp-frontend-search-controller/pull/185/files)

This is the use case.  Even though the header type is just []string, golang expects you to provide the local type which is sdk.header, and thus unexportable.

### Who can review

!me
