### PR TITLE
Fix distinct items count when query is not specified

### DIFF
--- a/query/search.go
+++ b/query/search.go
@@ -110,6 +110,7 @@ func SetupV710Count() (*template.Template, error) {
 	templates, err := template.ParseFS(searchFS,
 		"templates/search/v710/distinctItemCountQuery.tmpl",
 		"templates/search/v710/coreQuery.tmpl",
+		"templates/search/v710/matchAll.tmpl",
 	)
 
 	return templates, err

--- a/query/templates/search/v710/distinctItemCountQuery.tmpl
+++ b/query/templates/search/v710/distinctItemCountQuery.tmpl
@@ -3,7 +3,11 @@
 "query" : {
     "bool" : {
       "must" : [{
+      {{- if .Term}}
         {{- template "coreQuery.tmpl" .}}
+      {{- else}}
+        {{- template "matchAll.tmpl" .}}
+      {{- end}}
       },{
         "bool": {
             "must": {


### PR DESCRIPTION
### What

This pr attempts to return correct distinct items count when a query parameter is not specified. 

### How to review

Please check if the changes make sense. 

### Who can review

Anyone except me.
