### PR TITLE
allow multiple population types in query param (or filter)

### DIFF
--- a/api/search.go
+++ b/api/search.go
@@ -108,10 +108,6 @@ func CreateRequests(w http.ResponseWriter, req *http.Request, validator QueryPar
 		"value": topics,
 	})
 
-	popTypeParam := paramGet(params, "population_type", "")
-
-	dimensionsParam := paramGet(params, "dimensions", "")
-
 	limitParam := paramGet(params, "limit", "10")
 	limit, err := validator.Validate(ctx, "limit", limitParam)
 	if err != nil {
@@ -153,14 +149,21 @@ func CreateRequests(w http.ResponseWriter, req *http.Request, validator QueryPar
 		Now:       time.Now().UTC().Format(time.RFC3339),
 	}
 
-	// population type only used if provided
-	if popTypeParam != "" {
-		reqSearch.PopulationType = &query.PopulationTypeRequest{
-			Name: popTypeParam,
+	// population types only used if provided
+	popTypesParam := paramGet(params, "population_types", "")
+	if popTypesParam != "" {
+		popTypes := strings.Split(popTypesParam, ",")
+		p := make([]*query.PopulationTypeRequest, len(popTypes))
+		for i, popType := range popTypes {
+			p[i] = &query.PopulationTypeRequest{
+				Name: popType,
+			}
 		}
+		reqSearch.PopulationTypes = p
 	}
 
 	// dimensions only used if provided
+	dimensionsParam := paramGet(params, "dimensions", "")
 	if dimensionsParam != "" {
 		dims := strings.Split(dimensionsParam, ",")
 		d := make([]*query.DimensionRequest, len(dims))

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -345,7 +345,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 				"&limit=1"+
 				"&offset=2"+
 				"&dimensions=dim1,dim2"+
-				"&population_type=pop1",
+				"&population_types=pop1,pop2",
 			nil)
 		resp := httptest.NewRecorder()
 
@@ -362,8 +362,8 @@ func TestSearchHandlerFunc(t *testing.T) {
 		So(qbMock.BuildSearchQueryCalls()[0].Req.Dimensions, ShouldResemble, []*query.DimensionRequest{
 			{Name: "dim1"}, {Name: "dim2"},
 		})
-		So(qbMock.BuildSearchQueryCalls()[0].Req.PopulationType, ShouldResemble, &query.PopulationTypeRequest{
-			Name: "pop1",
+		So(qbMock.BuildSearchQueryCalls()[0].Req.PopulationTypes, ShouldResemble, []*query.PopulationTypeRequest{
+			{Name: "pop1"}, {Name: "pop2"},
 		})
 
 		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)

--- a/query/search.go
+++ b/query/search.go
@@ -18,10 +18,10 @@ const (
 )
 
 var es710AggregationField = &AggregationFields{
-	Topics:         "topics",
-	ContentTypes:   "type",
-	PopulationType: "population_type.name",
-	Dimensions:     "dimensions.name",
+	Topics:          "topics",
+	ContentTypes:    "type",
+	PopulationTypes: "population_type.name",
+	Dimensions:      "dimensions.name",
 }
 
 // SearchRequest holds the values provided by a request against Search API
@@ -39,7 +39,7 @@ type SearchRequest struct {
 	URIPrefix         string
 	Topic             []string
 	TopicWildcard     []string
-	PopulationType    *PopulationTypeRequest
+	PopulationTypes   []*PopulationTypeRequest
 	Dimensions        []*DimensionRequest
 	Now               string
 }
@@ -57,10 +57,10 @@ type DimensionRequest struct {
 
 // AggregationFields are the elasticsearch keys for which the aggregations will be done
 type AggregationFields struct {
-	Topics         string
-	ContentTypes   string
-	PopulationType string
-	Dimensions     string
+	Topics          string
+	ContentTypes    string
+	PopulationTypes string
+	Dimensions      string
 }
 
 type CountRequest struct {

--- a/query/templates/search/v710/contentFilters.tmpl
+++ b/query/templates/search/v710/contentFilters.tmpl
@@ -21,7 +21,7 @@
         }
       }
       {{ end }}
-      {{ if .PopulationType }}
+      {{ if .PopulationTypes }}
       , {
         "bool": {
           "should": [

--- a/query/templates/search/v710/countContentTypeFilters.tmpl
+++ b/query/templates/search/v710/countContentTypeFilters.tmpl
@@ -12,7 +12,7 @@
           ]
         }
       }
-      {{ if .PopulationType }}
+      {{ if .PopulationTypes }}
       , {
         "bool": {
           "should": [

--- a/query/templates/search/v710/countDimensionsFilters.tmpl
+++ b/query/templates/search/v710/countDimensionsFilters.tmpl
@@ -21,7 +21,7 @@
         }
       }
       {{ end }}
-      {{ if .PopulationType }}
+      {{ if .PopulationTypes }}
       , {
         "bool": {
           "should": [

--- a/query/templates/search/v710/countPopulationTypeQuery.tmpl
+++ b/query/templates/search/v710/countPopulationTypeQuery.tmpl
@@ -16,7 +16,7 @@
     "population_type": {
       "terms": {
         "size": 1000,
-  		  "field":"{{.AggregationFields.PopulationType}}"
+  		  "field":"{{.AggregationFields.PopulationTypes}}"
       }
   	 }
   }

--- a/query/templates/search/v710/countTopicFilters.tmpl
+++ b/query/templates/search/v710/countTopicFilters.tmpl
@@ -19,7 +19,7 @@
         }
       }
       {{ end }}
-      {{ if .PopulationType }}
+      {{ if .PopulationTypes }}
       , {
         "bool": {
           "should": [

--- a/query/templates/search/v710/populationTypeFilters.tmpl
+++ b/query/templates/search/v710/populationTypeFilters.tmpl
@@ -1,16 +1,19 @@
-{{ if .PopulationType.Name }}
-{
-  "match":{
-    "population_type.name": {
-      "query": "{{ .PopulationType.Name }}"
+{{range $i,$pop_type := .PopulationTypes}}
+    {{if $i}},{{end}}
+    {{ if $pop_type.Name }}
+    {
+        "match":{
+            "population_type.name": {
+                "query": "{{ $pop_type.Name }}"
+            }
+        }
+    },
+    {{ end }}
+    {
+        "match":{
+            "population_type.label": {
+                "query": "{{ $pop_type.Label }}"
+            }
+        }
     }
-  }
-},
-{{ end }}
-{
-  "match":{
-    "population_type.label": {
-      "query": "{{ .PopulationType.Label }}"
-    }
-  }
-}
+{{end}}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -90,13 +90,17 @@ paths:
           collectionFormat: csv
           required: false
         - in: query
-          name: population_type
-          description: "Determines the population type name to be returned."
-          type: string
+          name: population_types
+          description: "Comma separated list of population type names to filter the results (or)."
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+          collectionFormat: csv
           required: false
         - in: query
           name: dimensions
-          description: "Comma separated list of dimension names to be returned."
+          description: "Comma separated list of dimension names to filter the results (and)."
           type: array
           uniqueItems: true
           items:


### PR DESCRIPTION
### What

- Query param `population_type` is now `population_types` and allows a CSV list of population types to be provided for the filter
- Modify query template to apply an `or` filter using the provided population types
- Modify swagger spec accordingly

[Trello card](https://trello.com/c/x1MCxmIQ/1304-1304-search-api-should-allow-filtering-by-multiple-population-types)

### How to review

- Make sure changes make sense
- Make sure tests pass

### Who can review

Anyone, suggested @allandegnan 