### PR TITLE
remove cantabular content types and point to the latest version of dp…

### DIFF
--- a/api/search.go
+++ b/api/search.go
@@ -28,8 +28,6 @@ var defaultContentTypes = []string{
 	"compendium_data",
 	"dataset",
 	"dataset_landing_page",
-	"cantabular_flexible_table",
-	"cantabular_multivariate_table",
 	"product_page",
 	"reference_tables",
 	"release",

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -30,7 +30,6 @@ func TestValidateContentTypes(t *testing.T) {
 		disallowed, err := validateContentTypes([]string{
 			"dataset",
 			"dataset_landing_page",
-			"cantabular_flexible_table",
 		})
 		So(err, ShouldBeNil)
 		So(disallowed, ShouldHaveLength, 0)

--- a/cmd/reindex/main_test.go
+++ b/cmd/reindex/main_test.go
@@ -128,7 +128,7 @@ func TestTransformMetadataDoc(t *testing.T) {
 			}
 
 			expected := &importerModels.EsModel{
-				DataType:  "cantabular_flexible_table",
+				DataType:  "dataset_landing_page", // dataset_landing_page type is used for cantabular types
 				URI:       testURI,
 				DatasetID: testDatasetID,
 				Edition:   testEdition,

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ONSdigital/dp-elasticsearch/v3 v3.0.1-alpha.4.0.20230308115225-bb7559a89d0c
 	github.com/ONSdigital/dp-healthcheck v1.5.0
 	github.com/ONSdigital/dp-net/v2 v2.8.1
-	github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230302104007-3cf2c9ad4f52
+	github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230324131751-53efb665aa08
 	github.com/ONSdigital/dp-search-data-importer v0.10.1-0.20230317154853-8718b686237a
 	github.com/ONSdigital/log.go/v2 v2.3.0
 	github.com/cucumber/godog v0.12.5

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
 github.com/ONSdigital/dp-rchttp v1.0.0 h1:K/1/gDtfMZCX1Mbmq80nZxzDirzneqA1c89ea26FqP4=
 github.com/ONSdigital/dp-rchttp v1.0.0/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
-github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230302104007-3cf2c9ad4f52 h1:+nMQ4vV7NZN29ROiw9grQrzyrgkRMHN6zH9Z8TQmPnM=
-github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230302104007-3cf2c9ad4f52/go.mod h1:MpG+olMPeZNfYbvl2ve8fzsAgoxR7PmZV4smXKgti48=
+github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230324131751-53efb665aa08 h1:SzTZv/9mrBpvwdRLFzN1d2G/7dhCbbxvdslaK9xau6I=
+github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230324131751-53efb665aa08/go.mod h1:MpG+olMPeZNfYbvl2ve8fzsAgoxR7PmZV4smXKgti48=
 github.com/ONSdigital/dp-search-data-importer v0.10.1-0.20230317154853-8718b686237a h1:bCPcvst7dVQiFuGxt7WXJaoFocrqX7dmlKQHsszbgdI=
 github.com/ONSdigital/dp-search-data-importer v0.10.1-0.20230317154853-8718b686237a/go.mod h1:kwW5CKQiRvSJt2XbChOVqQKWAoutiFHOFZoRe7YgaDA=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=


### PR DESCRIPTION
### What

[Trello card](https://trello.com/c/W6dz9w4e/1307-1307-search-data-extractor-set-datasetlandingpage-type-for-cantabular-types)
- Remove cantabular contet types 
- update search-extractor dependency so that reindex sets `dataset_landing_page` for cantabular types

### How to review

- Make sure code changes make sense
- Make sure unit/component tests pass

### Who can review

Anyone