### PR TITLE
prevent panic in reindex if no previous index existed

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -401,7 +401,9 @@ func cleanOldIndices(ctx context.Context, dpEsIndexClient dpEsClient.Client) {
 		}
 	}
 
-	deleteIndicies(ctx, dpEsIndexClient, toDelete)
+	if len(toDelete) > 0 {
+		deleteIndicies(ctx, dpEsIndexClient, toDelete)
+	}
 }
 
 func doesIndexHaveAlias(details indexDetails, alias string) bool {


### PR DESCRIPTION
### What

- Call deleteIndex after a successful re-index only if there was already an existing index.
- Add debug logs (wrapped on a bool var) to display logs of api requests and queries sent to elasticsearch
The reason for these logs is that I kept adding and removing them to debug issues, so I think they will be useful for further debugging in the future, but maybe leaving them for production would cause too much noise.

### How to review

Make sure changes make sense

### Who can review

Anyone