### PR TITLE
define and use new label-based key in elasticsearch

### DIFF
--- a/api/search.go
+++ b/api/search.go
@@ -158,7 +158,7 @@ func CreateRequests(w http.ResponseWriter, req *http.Request, validator QueryPar
 		p := make([]*query.PopulationTypeRequest, len(popTypes))
 		for i, popType := range popTypes {
 			p[i] = &query.PopulationTypeRequest{
-				Name: popType,
+				Key: popType,
 			}
 		}
 		reqSearch.PopulationTypes = p
@@ -171,7 +171,7 @@ func CreateRequests(w http.ResponseWriter, req *http.Request, validator QueryPar
 		d := make([]*query.DimensionRequest, len(dims))
 		for i, dim := range dims {
 			d[i] = &query.DimensionRequest{
-				Name: dim,
+				Key: dim,
 			}
 		}
 		reqSearch.Dimensions = d

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -359,10 +359,10 @@ func TestSearchHandlerFunc(t *testing.T) {
 		So(qbMock.BuildSearchQueryCalls()[0].Req.Size, ShouldEqual, 1)
 		So(qbMock.BuildSearchQueryCalls()[0].Req.From, ShouldEqual, 2)
 		So(qbMock.BuildSearchQueryCalls()[0].Req.Dimensions, ShouldResemble, []*query.DimensionRequest{
-			{Name: "dim1"}, {Name: "dim2"},
+			{Key: "dim1"}, {Key: "dim2"},
 		})
 		So(qbMock.BuildSearchQueryCalls()[0].Req.PopulationTypes, ShouldResemble, []*query.PopulationTypeRequest{
-			{Name: "pop1"}, {Name: "pop2"},
+			{Key: "pop1"}, {Key: "pop2"},
 		})
 
 		So(esMock.MultiSearchCalls(), ShouldHaveLength, 1)

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -598,16 +598,18 @@ func convertToSearchDataModel(searchDataImport extractorModels.SearchDataImport)
 		})
 	}
 	searchDIM.PopulationType = importerModels.PopulationType{
+		Key:    searchDataImport.PopulationType.Key,
+		AggKey: searchDataImport.PopulationType.AggKey,
 		Name:   searchDataImport.PopulationType.Name,
 		Label:  searchDataImport.PopulationType.Label,
-		AggKey: searchDataImport.PopulationType.AggKey,
 	}
 	for _, dim := range searchDataImport.Dimensions {
 		searchDIM.Dimensions = append(searchDIM.Dimensions, importerModels.Dimension{
+			Key:      dim.Key,
+			AggKey:   dim.AggKey,
 			Name:     dim.Name,
 			Label:    dim.Label,
 			RawLabel: dim.RawLabel,
-			AggKey:   dim.AggKey,
 		})
 	}
 	return searchDIM

--- a/cmd/reindex/main_test.go
+++ b/cmd/reindex/main_test.go
@@ -133,14 +133,15 @@ func TestTransformMetadataDoc(t *testing.T) {
 				DatasetID: testDatasetID,
 				Edition:   testEdition,
 				PopulationType: &importerModels.EsPopulationType{
+					Key:    "all-usual-residents-in-households",
+					AggKey: "all-usual-residents-in-households###All usual residents in households",
 					Name:   "UR_HH",
 					Label:  "All usual residents in households",
-					AggKey: "UR_HH###All usual residents in households",
 				},
 				Dimensions: []importerModels.EsDimension{
-					{Name: "dim1", RawLabel: "label 1 (10 categories)", Label: "label 1", AggKey: "dim1###label 1"},
-					{Name: "dim2", RawLabel: "label 2 (12 Categories)", Label: "label 2", AggKey: "dim2###label 2"},
-					{Name: "dim4", RawLabel: "label 4 (1 category)", Label: "label 4", AggKey: "dim4###label 4"},
+					{Key: "label-1", AggKey: "label-1###label 1", Name: "dim1", RawLabel: "label 1 (10 categories)", Label: "label 1"},
+					{Key: "label-2", AggKey: "label-2###label 2", Name: "dim2", RawLabel: "label 2 (12 Categories)", Label: "label 2"},
+					{Key: "label-4", AggKey: "label-4###label 4", Name: "dim4", RawLabel: "label 4 (1 category)", Label: "label 4"},
 				},
 			}
 
@@ -161,7 +162,15 @@ func TestTransformMetadataDoc(t *testing.T) {
 				esModel := &importerModels.EsModel{}
 				err := json.Unmarshal(transformed.Body, esModel)
 				So(err, ShouldBeNil)
-				So(esModel, ShouldResemble, expected)
+				So(esModel.DataType, ShouldEqual, expected.DataType)
+				So(esModel.URI, ShouldEqual, expected.URI)
+				So(esModel.DatasetID, ShouldEqual, expected.DatasetID)
+				So(esModel.Edition, ShouldEqual, expected.Edition)
+				So(esModel.PopulationType, ShouldResemble, expected.PopulationType)
+				So(esModel.Dimensions, ShouldHaveLength, len(expected.Dimensions))
+				for _, dim := range expected.Dimensions {
+					So(esModel.Dimensions, ShouldContain, dim)
+				}
 
 				wg.Wait()
 			})

--- a/elasticsearch/search-index-settings.json
+++ b/elasticsearch/search-index-settings.json
@@ -304,20 +304,29 @@
       },
       "population_type": {
         "properties": {
+          "key": {
+            "type": "keyword"
+          },
+          "agg_key": {
+            "type": "keyword"
+          },
           "name": {
             "type":"keyword"
           },
           "label": {
             "type":"text",
             "analyzer":"ons_standard"
-          },
-          "agg_key": {
-            "type": "keyword"
           }
         }
       },
       "dimensions": {
         "properties": {
+          "key": {
+            "type": "keyword"
+          },
+          "agg_key": {
+            "type": "keyword"
+          },
           "name": {
             "type":"keyword"
           },
@@ -328,9 +337,6 @@
           "raw_label": {
             "type":"text",
             "analyzer":"ons_standard"
-          },
-          "agg_key": {
-            "type": "keyword"
           }
         }
       }

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/ONSdigital/dp-elasticsearch/v3 v3.0.1-alpha.4.0.20230308115225-bb7559a89d0c
 	github.com/ONSdigital/dp-healthcheck v1.5.0
 	github.com/ONSdigital/dp-net/v2 v2.8.1
-	github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230324155944-086207fe8b15
-	github.com/ONSdigital/dp-search-data-importer v0.10.1-0.20230324160829-5b40eedeb360
+	github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230329132748-048662c5ebf9
+	github.com/ONSdigital/dp-search-data-importer v0.10.1-0.20230329133747-4750f2abe8e1
 	github.com/ONSdigital/log.go/v2 v2.3.0
 	github.com/cucumber/godog v0.12.5
 	github.com/elastic/go-elasticsearch/v7 v7.10.0

--- a/go.sum
+++ b/go.sum
@@ -77,10 +77,10 @@ github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
 github.com/ONSdigital/dp-rchttp v1.0.0 h1:K/1/gDtfMZCX1Mbmq80nZxzDirzneqA1c89ea26FqP4=
 github.com/ONSdigital/dp-rchttp v1.0.0/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
-github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230324155944-086207fe8b15 h1:nSKXEGONP9VG7IogWgwEWtz8PFCSlZ2sk3u61PW9zdc=
-github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230324155944-086207fe8b15/go.mod h1:MpG+olMPeZNfYbvl2ve8fzsAgoxR7PmZV4smXKgti48=
-github.com/ONSdigital/dp-search-data-importer v0.10.1-0.20230324160829-5b40eedeb360 h1:fuEz/G8qyPFQtwTWvQrtviM5rHJZXhzEdxoYg0BJ4CI=
-github.com/ONSdigital/dp-search-data-importer v0.10.1-0.20230324160829-5b40eedeb360/go.mod h1:Ga33jxX6fSDhkNjTTlu0izqpx0tQHh1DST7DYygzWPQ=
+github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230329132748-048662c5ebf9 h1:vd46645/HH0trKH5XV0QGg35iB4VoiqWP3b57I+0rhE=
+github.com/ONSdigital/dp-search-data-extractor v0.17.1-0.20230329132748-048662c5ebf9/go.mod h1:MpG+olMPeZNfYbvl2ve8fzsAgoxR7PmZV4smXKgti48=
+github.com/ONSdigital/dp-search-data-importer v0.10.1-0.20230329133747-4750f2abe8e1 h1:2uuWg7pNnpTeLufmciQRN7dDyZVuaaJ8/mkzgZp3lfw=
+github.com/ONSdigital/dp-search-data-importer v0.10.1-0.20230329133747-4750f2abe8e1/go.mod h1:Ga33jxX6fSDhkNjTTlu0izqpx0tQHh1DST7DYygzWPQ=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad h1:Axoxm5rF6j7LSZfm4AGBT5IwGhWIcfcOkkhy/su/UpA=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad/go.mod h1:uHT6LaUlRbJsJRrIlN31t+QLUB80tAbk6ZR9sfoHL8Y=

--- a/query/search.go
+++ b/query/search.go
@@ -20,8 +20,8 @@ const (
 var es710AggregationField = &AggregationFields{
 	Topics:          "topics",
 	ContentTypes:    "type",
-	PopulationTypes: "population_type.agg_key", // agg_key is {name}###{label} so aggregations on unique combinations of these will be obtained
-	Dimensions:      "dimensions.agg_key",      // agg_key is {name}###{label} so aggregations on unique combinations of these will be obtained
+	PopulationTypes: "population_type.agg_key", // agg_key is {key}###{label} so aggregations on unique combinations of these will be obtained
+	Dimensions:      "dimensions.agg_key",      // agg_key is {key}###{label} so aggregations on unique combinations of these will be obtained
 }
 
 // SearchRequest holds the values provided by a request against Search API
@@ -45,11 +45,15 @@ type SearchRequest struct {
 }
 
 type PopulationTypeRequest struct {
-	Name  string
-	Label string
+	Key    string
+	AggKey string
+	Name   string
+	Label  string
 }
 
 type DimensionRequest struct {
+	Key      string
+	AggKey   string
 	Name     string
 	Label    string
 	RawLabel string

--- a/query/templates/search/v710/dimensionsFilters.tmpl
+++ b/query/templates/search/v710/dimensionsFilters.tmpl
@@ -3,6 +3,20 @@
     {
         "bool": {
             "should": [
+                {{ if $dim.Key }}
+                {
+                    "match":{
+                        "dimensions.key": "{{$dim.Key}}"
+                    }
+                },
+                {{ end }}
+                {{ if $dim.AggKey }}
+                {
+                    "match":{
+                        "dimensions.agg_key": "{{$dim.AggKey}}"
+                    }
+                },
+                {{ end }}
                 {{ if $dim.Name }}
                 {
                     "match":{

--- a/query/templates/search/v710/populationTypeFilters.tmpl
+++ b/query/templates/search/v710/populationTypeFilters.tmpl
@@ -1,5 +1,23 @@
 {{range $i,$pop_type := .PopulationTypes}}
     {{if $i}},{{end}}
+    {{ if $pop_type.Key }}
+    {
+        "match":{
+            "population_type.key": {
+                "query": "{{ $pop_type.Key }}"
+            }
+        }
+    },
+    {{ end }}
+    {{ if $pop_type.AggKey }}
+    {
+        "match":{
+            "population_type.agg_key": {
+                "query": "{{ $pop_type.AggKey }}"
+            }
+        }
+    },
+    {{ end }}
     {{ if $pop_type.Name }}
     {
         "match":{


### PR DESCRIPTION
### What

[Trello card](https://trello.com/c/bMrLzffC/1313-1313-de-duplicate-population-type-dimensions-in-search-extractor)

- add 'key' for dimensions and population type to elasticsearch json model.
- map it in the reindex script
- modify query template to allow filtering by dimension key and population type key
- use user provided query paramter to filter by key (instead of name)

### How to review

- Make sure code changes make sense
- Make sure tests pass
(Already tested to run a reindex locally with sandbox data)

### Who can review

Anyone