### PR TITLE
updating sequential execution of nlp requests

### DIFF
--- a/api/search.go
+++ b/api/search.go
@@ -560,10 +560,11 @@ func AddNlpToSearch(ctx context.Context, queryBuilder QueryBuilder, params url.V
 	brOpt := brlCli.OptInit()
 
 	// If berlin is down for any reason,
-	// we need to change the query from berlin.Query to scrubber.Query from interfering with regular dp-search-api resp
+	// We need to change the query from berlin.Query to scrubber.Query from interfering with regular dp-search-api resp
 	berlin, err = clList.BerlinClient.GetBerlin(ctx, *brOpt.Q(scrubber.Query))
 	if err != nil {
 		log.Error(ctx, "error making request to berlin", err)
+		// if berlin isn't working we need to make sure the query is accessible to category
 		berlin = &brModel.Berlin{
 			Query: scrubber.Query,
 		}
@@ -608,7 +609,7 @@ func AddNlpToSearch(ctx context.Context, queryBuilder QueryBuilder, params url.V
 
 	// If berlin exists, add the subdivisions to NLP criteria.
 	// They'll be used later in the query to ElasticSearch
-	if berlin != nil && len(berlin.Matches) > 0 && len(berlin.Matches[0].Loc.Subdivision) == 2 {
+	if len(berlin.Matches) > 0 && len(berlin.Matches[0].Loc.Subdivision) == 2 {
 		nlpCriteria = queryBuilder.AddNlpSubdivisionSearch(nlpCriteria, berlin.Matches[0].Loc.Subdivision[1])
 	}
 

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -1330,7 +1330,7 @@ func newCategoryClienterMock(response *[]catModels.Category, err catErr.Error) *
 
 func newScrubberClienterMock(response *scrModels.ScrubberResp, err catErr.Error) *scrMocks.ClienterMock {
 	return &scrMocks.ClienterMock{
-		GetScrubberFunc: func(ctx context.Context, options scr.Options) (*scrModels.ScrubberResp, scrErr.Error) {
+		GetScrubberFunc: func(ctx context.Context, options *scr.Options) (*scrModels.ScrubberResp, scrErr.Error) {
 			return response, err
 		},
 	}

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -99,7 +99,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?limit=a", http.NoBody)
 		resp := httptest.NewRecorder()
@@ -117,7 +117,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?limit=-1", http.NoBody)
 		resp := httptest.NewRecorder()
@@ -135,7 +135,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?offset=b", http.NoBody)
 		resp := httptest.NewRecorder()
@@ -153,7 +153,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?offset=-1", http.NoBody)
 		resp := httptest.NewRecorder()
@@ -171,7 +171,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?content_type=wrong1,wrong2", http.NoBody)
 		resp := httptest.NewRecorder()
@@ -189,7 +189,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -207,7 +207,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock(nil, errors.New("Something"))
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -227,7 +227,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock([]byte(`{"dummy":"response"`), nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -247,7 +247,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock(nil, errors.New("Something"))
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -270,7 +270,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock([]byte(`{"dummy":"response"}`), nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam+rawTrue, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -293,7 +293,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -318,7 +318,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam+highlightTrue, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -343,7 +343,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam+highlightFalse, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -368,7 +368,7 @@ func TestSearchHandlerFunc(t *testing.T) {
 		esMock := newDpElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{dpESClient: esMock}, trMock)
+		searchHandler := SearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DpESClient: esMock}, trMock)
 
 		req := httptest.NewRequest(
 			"GET",
@@ -422,9 +422,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 		brMock := newBerlinClienterMock(&brModels.Berlin{
 			Matches: []brModels.Matches{
 				{
-					Subdivision: []string{
-						"subdiv1",
-						"subdiv2",
+					Loc: brModels.Locations{
+						Subdivision: []string{
+							"subdiv1",
+							"subdiv2",
+						},
 					},
 				},
 			},
@@ -450,11 +452,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		clList := ClientList{
-			scrubberClient: scrMock,
-			categoryClient: catMock,
-			berlinClient:   brMock,
-			dpESClient:     esMock,
+		clList := &ClientList{
+			ScrubberClient: scrMock,
+			CategoryClient: catMock,
+			BerlinClient:   brMock,
+			DpESClient:     esMock,
 		}
 
 		cfg := &config.Config{
@@ -505,9 +507,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 		brMock := newBerlinClienterMock(&brModels.Berlin{
 			Matches: []brModels.Matches{
 				{
-					Subdivision: []string{
-						"subdiv1",
-						"subdiv2",
+					Loc: brModels.Locations{
+						Subdivision: []string{
+							"subdiv1",
+							"subdiv2",
+						},
 					},
 				},
 			},
@@ -533,11 +537,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		clList := ClientList{
-			scrubberClient: scrMock,
-			categoryClient: catMock,
-			berlinClient:   brMock,
-			dpESClient:     esMock,
+		clList := &ClientList{
+			ScrubberClient: scrMock,
+			CategoryClient: catMock,
+			BerlinClient:   brMock,
+			DpESClient:     esMock,
 		}
 
 		cfg := &config.Config{
@@ -588,9 +592,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 		brMock := newBerlinClienterMock(&brModels.Berlin{
 			Matches: []brModels.Matches{
 				{
-					Subdivision: []string{
-						"subdiv1",
-						"subdiv2",
+					Loc: brModels.Locations{
+						Subdivision: []string{
+							"subdiv1",
+							"subdiv2",
+						},
 					},
 				},
 			},
@@ -609,11 +615,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		clList := ClientList{
-			scrubberClient: scrMock,
-			categoryClient: catMock,
-			berlinClient:   brMock,
-			dpESClient:     esMock,
+		clList := &ClientList{
+			ScrubberClient: scrMock,
+			CategoryClient: catMock,
+			BerlinClient:   brMock,
+			DpESClient:     esMock,
 		}
 
 		cfg := &config.Config{
@@ -688,11 +694,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		clList := ClientList{
-			scrubberClient: scrMock,
-			categoryClient: catMock,
-			berlinClient:   brMock,
-			dpESClient:     esMock,
+		clList := &ClientList{
+			ScrubberClient: scrMock,
+			CategoryClient: catMock,
+			BerlinClient:   brMock,
+			DpESClient:     esMock,
 		}
 
 		cfg := &config.Config{
@@ -764,11 +770,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		clList := ClientList{
-			scrubberClient: scrMock,
-			categoryClient: catMock,
-			berlinClient:   brMock,
-			dpESClient:     esMock,
+		clList := &ClientList{
+			ScrubberClient: scrMock,
+			CategoryClient: catMock,
+			BerlinClient:   brMock,
+			DpESClient:     esMock,
 		}
 
 		cfg := &config.Config{
@@ -818,9 +824,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 		brMock := newBerlinClienterMock(&brModels.Berlin{
 			Matches: []brModels.Matches{
 				{
-					Subdivision: []string{
-						"subdiv1",
-						"subdiv2",
+					Loc: brModels.Locations{
+						Subdivision: []string{
+							"subdiv1",
+							"subdiv2",
+						},
 					},
 				},
 			},
@@ -843,11 +851,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		clList := ClientList{
-			scrubberClient: scrMock,
-			categoryClient: catMock,
-			berlinClient:   brMock,
-			dpESClient:     esMock,
+		clList := &ClientList{
+			ScrubberClient: scrMock,
+			CategoryClient: catMock,
+			BerlinClient:   brMock,
+			DpESClient:     esMock,
 		}
 
 		cfg := &config.Config{
@@ -903,11 +911,11 @@ func TestSearchHandlerFunc(t *testing.T) {
 
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		clList := ClientList{
-			scrubberClient: scrMock,
-			categoryClient: catMock,
-			berlinClient:   brMock,
-			dpESClient:     esMock,
+		clList := &ClientList{
+			ScrubberClient: scrMock,
+			CategoryClient: catMock,
+			BerlinClient:   brMock,
+			DpESClient:     esMock,
 		}
 
 		cfg := &config.Config{
@@ -958,7 +966,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?limit=a", http.NoBody)
 		resp := httptest.NewRecorder()
@@ -976,7 +984,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?limit=-1", http.NoBody)
 		resp := httptest.NewRecorder()
@@ -994,7 +1002,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?offset=b", http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1012,7 +1020,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?offset=-1", http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1030,7 +1038,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock(nil, nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1049,7 +1057,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock(nil, errors.New("Something"))
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1070,7 +1078,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(`{"dummy":"response"`), nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1091,7 +1099,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock(nil, errors.New("Something"))
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1115,7 +1123,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(`{"dummy":"response"}`), nil)
 		trMock := newResponseTransformerMock(nil, nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam+rawTrue, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1137,7 +1145,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1162,7 +1170,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam+highlightTrue, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1187,7 +1195,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest("GET", baseURL+validQueryParam+highlightFalse, http.NoBody)
 		resp := httptest.NewRecorder()
@@ -1212,7 +1220,7 @@ func TestLegacySearchHandlerFunc(t *testing.T) {
 		esMock := newElasticSearcherMock([]byte(validESResponse), nil)
 		trMock := newResponseTransformerMock([]byte(validTransformedResponse), nil)
 
-		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, ClientList{deprecatedESClient: esMock}, trMock)
+		searchHandler := LegacySearchHandlerFunc(validator, qbMock, &config.Config{}, &ClientList{DeprecatedESClient: esMock}, trMock)
 
 		req := httptest.NewRequest(
 			"GET",
@@ -1250,8 +1258,8 @@ func TestCreateSearchIndexHandlerFunc(t *testing.T) {
 		dpESClient := newDpElasticSearcherMock(nil, nil)
 
 		searchAPI := &SearchAPI{
-			clList: ClientList{
-				dpESClient: dpESClient,
+			clList: &ClientList{
+				DpESClient: dpESClient,
 			},
 		}
 
@@ -1285,8 +1293,8 @@ func TestCreateSearchIndexHandlerFunc(t *testing.T) {
 		dpESClient := newDpElasticSearcherMock(nil, errors.New("unexpected status code from api"))
 
 		searchAPI := &SearchAPI{
-			clList: ClientList{
-				dpESClient: dpESClient,
+			clList: &ClientList{
+				DpESClient: dpESClient,
 			},
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.55.0
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.7.0
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.257.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.258.0
 	github.com/ONSdigital/dp-authorisation v0.2.0
 	github.com/ONSdigital/dp-component-test v0.9.0
 	github.com/ONSdigital/dp-elasticsearch/v3 v3.0.1-alpha.4.0.20230308115225-bb7559a89d0c

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.6.2
 	github.com/ONSdigital/dp-net/v2 v2.11.2
 	github.com/ONSdigital/dp-otel-go v0.0.6
-	github.com/ONSdigital/dp-search-scrubber-api v0.3.0
+	github.com/ONSdigital/dp-search-scrubber-api v0.4.1
 	github.com/ONSdigital/log.go/v2 v2.4.3
 	github.com/cucumber/godog v0.12.6
 	github.com/elastic/go-elasticsearch/v7 v7.10.0

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.257.0 h1:m+sYA4SbFbQjyXUTbW8iFgrH4BJ4A8vEZa2ZChZKCQw=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.257.0/go.mod h1:5ltM5gaLFCnWr9WmPyRDm6oLH5WaZNmalYQqx90RB68=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.258.0 h1:ppCxvjMnxqOmroncGnqyooB0I3Boc9ueuyo2j5N1bEY=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.258.0/go.mod h1:5ltM5gaLFCnWr9WmPyRDm6oLH5WaZNmalYQqx90RB68=
 github.com/ONSdigital/dp-authorisation v0.2.0 h1:QVjTUSR3c1swZwP7lMbvnBsh4Je9oc54eGzgwPOvHOc=
 github.com/ONSdigital/dp-authorisation v0.2.0/go.mod h1:Tg3BiohT3+bRv4vr4aid/1Rf+S3eXLUI8oHbOLFqFpQ=
 github.com/ONSdigital/dp-component-test v0.9.0 h1:DfSvL1CKrZ4Jm/WqNLw27DtOcn2fmPI6KNx9zaFYgCo=

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
 github.com/ONSdigital/dp-rchttp v1.0.0 h1:K/1/gDtfMZCX1Mbmq80nZxzDirzneqA1c89ea26FqP4=
 github.com/ONSdigital/dp-rchttp v1.0.0/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
-github.com/ONSdigital/dp-search-scrubber-api v0.3.0 h1:MyndPyKuHXdID3m/HdLy8ryQ5/fztcfu95KWB6/q2Xg=
-github.com/ONSdigital/dp-search-scrubber-api v0.3.0/go.mod h1:eQ+MFFCnZhfgfuHPejuQDD3KJE0yYnmQEgeZpti8rwc=
+github.com/ONSdigital/dp-search-scrubber-api v0.4.1 h1:aj0g1hUZENS9PB+BHhasCIvuE9i+/OSgL9AqCmed5dw=
+github.com/ONSdigital/dp-search-scrubber-api v0.4.1/go.mod h1:eQ+MFFCnZhfgfuHPejuQDD3KJE0yYnmQEgeZpti8rwc=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad h1:Axoxm5rF6j7LSZfm4AGBT5IwGhWIcfcOkkhy/su/UpA=
 github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad/go.mod h1:uHT6LaUlRbJsJRrIlN31t+QLUB80tAbk6ZR9sfoHL8Y=

--- a/service/service.go
+++ b/service/service.go
@@ -132,7 +132,11 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		return nil, err
 	}
 
-	if regErr := registerCheckers(ctx, healthCheck, esClient); regErr != nil {
+	// Create a ClientList to store all the required clients
+	// Remove deprecatedESClient once the legacy handler is removed
+	clList := api.NewClientList(berlinClient, categoryClient, esClient, scrubberClient, deprecatedESClient)
+
+	if regErr := registerCheckers(ctx, healthCheck, clList); regErr != nil {
 		return nil, errors.Wrap(regErr, "unable to register checkers")
 	}
 
@@ -148,10 +152,6 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	}
 	router.StrictSlash(true).Path("/health").HandlerFunc(healthCheck.Handler)
 	healthCheck.Start(ctx)
-
-	// Create a ClientList to store all the required clients
-	// Remove deprecatedESClient once the legacy handler is removed
-	clList := api.NewClientList(berlinClient, categoryClient, esClient, scrubberClient, deprecatedESClient)
 
 	// Create Search API and register HTTP handlers
 	searchAPI := api.NewSearchAPI(router, clList, permissions).
@@ -228,10 +228,16 @@ func (svc *Service) Close(ctx context.Context) error {
 	return nil
 }
 
-func registerCheckers(ctx context.Context, hc HealthChecker, dpESClient dpEsClient.Client) (err error) {
-	if err = hc.AddCheck("Elasticsearch", dpESClient.Checker); err != nil {
+func registerCheckers(ctx context.Context, hc HealthChecker, clList *api.ClientList) (err error) {
+	if err = hc.AddCheck("Elasticsearch", clList.DpESClient.Checker); err != nil {
 		log.Error(ctx, "error creating elasticsearch health check", err)
 		err = errors.New("Error(s) registering checkers for health check")
 	}
+
+	if err = hc.AddCheck("Scrubber-API", clList.ScrubberClient.Checker); err != nil {
+		log.Error(ctx, "error creating elasticsearch health check", err)
+		err = errors.New("Error(s) registering checkers for health check")
+	}
+
 	return err
 }

--- a/service/service.go
+++ b/service/service.go
@@ -229,25 +229,7 @@ func (svc *Service) Close(ctx context.Context) error {
 }
 
 func registerCheckers(ctx context.Context, hc HealthChecker, clList *api.ClientList) (err error) {
-	if err = hc.AddCheck("Berlin-API", clList.BerlinClient.Checker); err != nil {
-		log.Error(ctx, "error creating elasticsearch health check", err)
-		err = errors.New("Error(s) registering checkers for health check")
-		return err
-	}
-
-	if err = hc.AddCheck("Category-API", clList.ScrubberClient.Checker); err != nil {
-		log.Error(ctx, "error creating elasticsearch health check", err)
-		err = errors.New("Error(s) registering checkers for health check")
-		return err
-	}
-
 	if err = hc.AddCheck("Elasticsearch", clList.DpESClient.Checker); err != nil {
-		log.Error(ctx, "error creating elasticsearch health check", err)
-		err = errors.New("Error(s) registering checkers for health check")
-		return err
-	}
-
-	if err = hc.AddCheck("Scrubber-API", clList.ScrubberClient.Checker); err != nil {
 		log.Error(ctx, "error creating elasticsearch health check", err)
 		err = errors.New("Error(s) registering checkers for health check")
 		return err

--- a/service/service.go
+++ b/service/service.go
@@ -229,15 +229,29 @@ func (svc *Service) Close(ctx context.Context) error {
 }
 
 func registerCheckers(ctx context.Context, hc HealthChecker, clList *api.ClientList) (err error) {
+	if err = hc.AddCheck("Berlin-API", clList.BerlinClient.Checker); err != nil {
+		log.Error(ctx, "error creating elasticsearch health check", err)
+		err = errors.New("Error(s) registering checkers for health check")
+		return err
+	}
+
+	if err = hc.AddCheck("Category-API", clList.ScrubberClient.Checker); err != nil {
+		log.Error(ctx, "error creating elasticsearch health check", err)
+		err = errors.New("Error(s) registering checkers for health check")
+		return err
+	}
+
 	if err = hc.AddCheck("Elasticsearch", clList.DpESClient.Checker); err != nil {
 		log.Error(ctx, "error creating elasticsearch health check", err)
 		err = errors.New("Error(s) registering checkers for health check")
+		return err
 	}
 
 	if err = hc.AddCheck("Scrubber-API", clList.ScrubberClient.Checker); err != nil {
 		log.Error(ctx, "error creating elasticsearch health check", err)
 		err = errors.New("Error(s) registering checkers for health check")
+		return err
 	}
 
-	return err
+	return nil
 }


### PR DESCRIPTION
### What

Updated sequential execution of nlp api requests to make sure berlin scrubs any locations from the query before it's given to category matcher.

Things to change once that's done: use scrubber sdk.OptIniti() which creates an options struct to avoid nil value dereferences.

### How to review

Check for consistency
Check CI steps

### Who can review

Linden