### PR TITLE
Feature/add provisional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ debug: ## Used to run code locally
 debug-run: ## Used to build and run code locally in debug mode
 	HUMAN_LOG=1 DEBUG=1 go run -tags 'debug' -race $(LDFLAGS) main.go
 
+.PHONY: debug-watch
+debug-watch: 
+	reflex -d none -c ./reflex
+
 .PHONY: delimiter-%
 delimiter-%:
 	@echo '===================${GREEN} $* ${RESET}==================='

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0 h1:1u/AyyOqAWzy+SkPxDp
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0/go.mod h1:z46paqbJ9l7c9fIPCXTqTGwhQZ5XoTIsfeFYWboizjs=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0 h1:tIqheXEFWAZ7O8A7m+J0aPTmpJN3YQ7qetUAdkkkKpk=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0/go.mod h1:nUeKExfxAQVbiVFn32YXpXZZHZ61Cc3s3Rn1pDBGAb0=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0 h1:Waw9Wfpo/IXzOI8bCB7DIk+0JZcqqsyn1JFnAc+iam8=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0/go.mod h1:wnJIG4fOqyynOnnQF/eQb4/16VlX2EJAHhHgqIqWfAo=
 go.opentelemetry.io/otel/metric v1.26.0 h1:7S39CLuY5Jgg9CrnA9HHiEjGMF/X2VHvoXGgSllRz30=
 go.opentelemetry.io/otel/metric v1.26.0/go.mod h1:SY+rHOI4cEawI9a7N1A4nIg/nTQXe1ccCNWYOJUrpX4=
 go.opentelemetry.io/otel/sdk v1.26.0 h1:Y7bumHf5tAiDlRYFmGqetNcLaVUZmh4iYfmGxtmz7F8=

--- a/transformer/releasetransformer.go
+++ b/transformer/releasetransformer.go
@@ -90,17 +90,18 @@ type ESReleaseResponseHit struct {
 }
 
 type ESReleaseSourceDocument struct {
-	URI         string       `json:"uri"`
-	Title       string       `json:"title"`
-	Summary     string       `json:"summary"`
-	ReleaseDate string       `json:"release_date,omitempty"`
-	Published   bool         `json:"published"`
-	Cancelled   bool         `json:"cancelled"`
-	Finalised   bool         `json:"finalised"`
-	Survey      string       `json:"survey"`
-	Keywords    []string     `json:"keywords,omitempty"`
-	Language    string       `json:"language,omitempty"`
-	DateChanges []dateChange `json:"date_changes,omitempty"`
+	URI             string       `json:"uri"`
+	Title           string       `json:"title"`
+	Summary         string       `json:"summary"`
+	ReleaseDate     string       `json:"release_date,omitempty"`
+	Published       bool         `json:"published"`
+	Cancelled       bool         `json:"cancelled"`
+	Finalised       bool         `json:"finalised"`
+	Survey          string       `json:"survey"`
+	Keywords        []string     `json:"keywords,omitempty"`
+	Language        string       `json:"language,omitempty"`
+	DateChanges     []dateChange `json:"date_changes,omitempty"`
+	ProvisionalDate string       `json:"provisional_date,omitempty"`
 }
 
 type dateChange struct {
@@ -211,16 +212,17 @@ func buildRelease(hit ESReleaseResponseHit, highlighter *strings.Replacer) Relea
 	r := Release{
 		URI: hit.Source.URI,
 		Description: ReleaseDescription{
-			Title:       sd.Title,
-			Summary:     sd.Summary,
-			ReleaseDate: sd.ReleaseDate,
-			Published:   sd.Published,
-			Cancelled:   sd.Cancelled,
-			Finalised:   sd.Finalised,
-			Postponed:   isPostponed(sd),
-			Census:      isCensus(sd),
-			Keywords:    sd.Keywords,
-			Language:    sd.Language,
+			Title:           sd.Title,
+			Summary:         sd.Summary,
+			ReleaseDate:     sd.ReleaseDate,
+			Published:       sd.Published,
+			Cancelled:       sd.Cancelled,
+			Finalised:       sd.Finalised,
+			Postponed:       isPostponed(sd),
+			Census:          isCensus(sd),
+			Keywords:        sd.Keywords,
+			Language:        sd.Language,
+			ProvisionalDate: sd.ProvisionalDate,
 		},
 	}
 

--- a/transformer/testdata/search_release_es_response.json
+++ b/transformer/testdata/search_release_es_response.json
@@ -43,7 +43,8 @@
               "topics":null,
               "finalised":true,
               "cancelled":false,
-              "published":false
+              "published":false,
+              "provisional_date": "August to September"
             },
             "highlight":{
               "summary":[

--- a/transformer/testdata/search_release_expected_highlighted.json
+++ b/transformer/testdata/search_release_expected_highlighted.json
@@ -22,6 +22,7 @@
         "census":false,
         "national_statistic":false,
         "latest_release":false,
+        "provisional_date": "August to September",
         "contact":{
           "name":"Sarah Caul",
           "telephone":"+44 (0)1633 456490",
@@ -47,6 +48,7 @@
         "national_statistic":true,
         "next_release":"22 November 2018",
         "latest_release":false,
+        "provisional_date": "2018-08-23",
         "contact":{
           "name":"Yanitsa Petkova ",
           "telephone":"+44 (0)1633 651599 ",

--- a/transformer/testdata/search_release_expected_plain.json
+++ b/transformer/testdata/search_release_expected_plain.json
@@ -21,6 +21,7 @@
         "postponed":true,
         "national_statistic":false,
         "latest_release":false,
+        "provisional_date": "August to September",
         "contact":{
           "name":"Sarah Caul",
           "telephone":"+44 (0)1633 456490",


### PR DESCRIPTION
### What

Mapped provisional_date to the /search/releases response. 

### How to review

To work with https://github.com/ONSdigital/dp-frontend-release-calendar/pull/195
Check looks ok - if you want to check end to end you'll need to index some releases that are provisional into your local search index. 

### Who can review

Not me. 