### PR TITLE
Feature/update swagger

### DIFF
--- a/api/releases_test.go
+++ b/api/releases_test.go
@@ -38,7 +38,7 @@ func TestSearchReleasesHandlerFunc(t *testing.T) {
 	searchHandler := SearchReleasesHandlerFunc(validator, builder, searcher, transformer)
 
 	convey.Convey("Should return BadRequest for invalid limit parameter", t, func() {
-		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?limit=test", nil)
+		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?limit=test", http.NoBody)
 		resp := httptest.NewRecorder()
 
 		searchHandler.ServeHTTP(resp, req)
@@ -48,7 +48,7 @@ func TestSearchReleasesHandlerFunc(t *testing.T) {
 	})
 
 	convey.Convey("Should return BadRequest for invalid offset parameter", t, func() {
-		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?offset=test", nil)
+		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?offset=test", http.NoBody)
 		resp := httptest.NewRecorder()
 
 		searchHandler.ServeHTTP(resp, req)
@@ -58,7 +58,7 @@ func TestSearchReleasesHandlerFunc(t *testing.T) {
 	})
 
 	convey.Convey("Should return BadRequest for invalid sort parameter", t, func() {
-		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?sort=test", nil)
+		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?sort=test", http.NoBody)
 		resp := httptest.NewRecorder()
 
 		searchHandler.ServeHTTP(resp, req)
@@ -68,7 +68,7 @@ func TestSearchReleasesHandlerFunc(t *testing.T) {
 	})
 
 	convey.Convey("Should return valid response for correct parameters", t, func() {
-		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?query=test", nil)
+		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?query=test", http.NoBody)
 		resp := httptest.NewRecorder()
 
 		searchHandler.ServeHTTP(resp, req)

--- a/api/releases_test.go
+++ b/api/releases_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ONSdigital/dp-elasticsearch/v3/client"
+	"github.com/ONSdigital/dp-search-api/query"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestSearchReleasesHandlerFunc(t *testing.T) {
+	validator := query.NewReleaseQueryParamValidator()
+	builder := &ReleaseQueryBuilderMock{
+		BuildSearchQueryFunc: func(ctx context.Context, request interface{}) ([]client.Search, error) {
+			return []client.Search{
+				{Query: []byte(`{"query": "test"}`)},
+			}, nil
+		},
+	}
+	searcher := &DpElasticSearcherMock{
+		MultiSearchFunc: func(ctx context.Context, searches []client.Search, params *client.QueryParams) ([]byte, error) {
+			searchResponse := map[string]interface{}{
+				"dummy": "response",
+			}
+			return json.Marshal(searchResponse)
+		},
+	}
+	transformer := &ReleaseResponseTransformerMock{
+		TransformSearchResponseFunc: func(ctx context.Context, responseData []byte, req query.ReleaseSearchRequest, highlight bool) ([]byte, error) {
+			return responseData, nil
+		},
+	}
+
+	searchHandler := SearchReleasesHandlerFunc(validator, builder, searcher, transformer)
+
+	convey.Convey("Should return BadRequest for invalid limit parameter", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?limit=test", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		convey.So(resp.Code, convey.ShouldEqual, http.StatusBadRequest)
+		convey.So(resp.Body.String(), convey.ShouldContainSubstring, "Invalid limit parameter")
+	})
+
+	convey.Convey("Should return BadRequest for invalid offset parameter", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?offset=test", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		convey.So(resp.Code, convey.ShouldEqual, http.StatusBadRequest)
+		convey.So(resp.Body.String(), convey.ShouldContainSubstring, "Invalid offset parameter")
+	})
+
+	convey.Convey("Should return BadRequest for invalid sort parameter", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?sort=test", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		convey.So(resp.Code, convey.ShouldEqual, http.StatusBadRequest)
+		convey.So(resp.Body.String(), convey.ShouldContainSubstring, "Invalid sort parameter")
+	})
+
+	convey.Convey("Should return valid response for correct parameters", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080/search/releases?query=test", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		convey.So(resp.Code, convey.ShouldEqual, http.StatusOK)
+		convey.So(resp.Body.String(), convey.ShouldContainSubstring, `{"dummy":"response"}`)
+	})
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -219,7 +219,7 @@ paths:
           default: true
         - in: query
           name: census
-          description: Whether to only include census releases in the results.
+          description: "Whether to only include census releases in the results."
           type: boolean
           required: false
           default: false

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -191,7 +191,7 @@ paths:
           required: false
           default: "release_date_asc"
         - in: query
-          name: q
+          name: query
           description: "Query keywords"
           type: string
           required: false
@@ -206,17 +206,23 @@ paths:
           type: string
           required: false
         - in: query
-          name: upcoming
-          description: "Determines whether to return Upcoming Release Calendar Entries or Published Releases"
-          type: boolean
+          name: release-type
+          description: "The type of releases to include in the results."
+          type: string
           required: false
-          default: false
+          default: type-published
         - in: query
           name: highlight
           description: "Determines whether to return HTML highlighted fields."
           type: boolean
           required: false
           default: true
+        - in: query
+          name: census
+          description: Whether to only include census releases in the results.
+          type: boolean
+          required: false
+          default: false
       responses:
         200:
           description: OK


### PR DESCRIPTION
### What

- Updated the swagger
- Added unit tests for releases.go

The api looks like it can also take params for `subtype-provisional`, `subtype-confirmed`, and `subtype-postponed` but with some testing they didn't seem to do anything, so didn't include them. Could be wrong on that.

### How to review

Tests pass and didn't miss anything in the swagger

### Who can review

Not me
