### PR TITLE
Fix/lock uris to exact match

### DIFF
--- a/query/templates/search/v710/countContentTypeFilters.tmpl
+++ b/query/templates/search/v710/countContentTypeFilters.tmpl
@@ -21,6 +21,15 @@
         }
       }
       {{ end }}
+      {{ if .URIs }}
+      , {
+        "bool": {
+          "should": [
+            {{ template "uriFilters.tmpl". }}
+          ]
+        }
+      }
+      {{ end }}
       {{ if .Dimensions }}
       , {
         "bool": {

--- a/query/templates/search/v710/countDimensionsFilters.tmpl
+++ b/query/templates/search/v710/countDimensionsFilters.tmpl
@@ -21,6 +21,15 @@
         }
       }
       {{ end }}
+      {{ if .URIs }}
+      , {
+        "bool": {
+          "should": [
+            {{ template "uriFilters.tmpl". }}
+          ]
+        }
+      }
+      {{ end }}
       {{ if .PopulationTypes }}
       , {
         "bool": {

--- a/query/templates/search/v710/countPopulationTypeFilters.tmpl
+++ b/query/templates/search/v710/countPopulationTypeFilters.tmpl
@@ -21,6 +21,15 @@
         }
       }
       {{ end }}
+      {{ if .URIs }}
+      , {
+        "bool": {
+          "should": [
+            {{ template "uriFilters.tmpl". }}
+          ]
+        }
+      }
+      {{ end }}
       {{ if .Dimensions }}
       , {
         "bool": {

--- a/query/templates/search/v710/countTopicFilters.tmpl
+++ b/query/templates/search/v710/countTopicFilters.tmpl
@@ -19,6 +19,15 @@
         }
       }
       {{ end }}
+      {{ if .URIs }}
+      , {
+        "bool": {
+          "should": [
+            {{ template "uriFilters.tmpl". }}
+          ]
+        }
+      }
+      {{ end }}
       {{ if .PopulationTypes }}
       , {
         "bool": {

--- a/query/templates/search/v710/uriFilters.tmpl
+++ b/query/templates/search/v710/uriFilters.tmpl
@@ -1,7 +1,7 @@
 {{range $i, $e := .URIs}}
 {{if $i}},{{end}}
 {
-   "prefix": {
+   "match": {
       "uri": "{{.}}"
    }
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -224,7 +224,7 @@ paths:
     post:
       tags:
         - public
-      summary: "Search URIs by prefix"
+      summary: "Search URIs by list"
       description: "Accepts a list of URIs and returns matching results based on provided criteria."
       parameters:
         - in: body


### PR DESCRIPTION
### What

Made URIs an exact match to ensure functionality for /relatedData will work as expected.
Added URI filter to count templates as well to cover off that use. 

### How to review

Populate search index via reindex-batch, run dp-search-api
Make POST request to /search/uris and include multiple uris - should now see this will only return exact matches rather than prefixes. 

### Who can review

Not me.