### PR TITLE
feature/add known characters to whitelist

### DIFF
--- a/api/search.go
+++ b/api/search.go
@@ -71,6 +71,9 @@ var defaultContentTypes = []string{
 	"timeseries_dataset",
 }
 
+// contains the special characters that are allowed in query validation
+const AllowedSpecialCharacters = "–‘’"
+
 type URIsRequest struct {
 	URIs   []string `json:"uris"`
 	Limit  int      `json:"limit,omitempty"`  // Limit is optional
@@ -835,7 +838,7 @@ func sanitiseDoubleQuotes(str string) string {
 }
 
 func checkForSpecialCharacters(str string) bool {
-	re := regexp.MustCompile("[^[:ascii:]–‘’]")
+	re := regexp.MustCompile(fmt.Sprintf("[^[:ascii:]%s]", regexp.QuoteMeta(AllowedSpecialCharacters)))
 	return re.MatchString(str)
 }
 

--- a/api/search.go
+++ b/api/search.go
@@ -835,7 +835,7 @@ func sanitiseDoubleQuotes(str string) string {
 }
 
 func checkForSpecialCharacters(str string) bool {
-	re := regexp.MustCompile("[[:^ascii:]]")
+	re := regexp.MustCompile("[[:^ascii:]&&[^–‘’]]")
 	return re.MatchString(str)
 }
 

--- a/api/search.go
+++ b/api/search.go
@@ -835,7 +835,7 @@ func sanitiseDoubleQuotes(str string) string {
 }
 
 func checkForSpecialCharacters(str string) bool {
-	re := regexp.MustCompile("[[:^ascii:]&&[^–‘’]]")
+	re := regexp.MustCompile("[^[:ascii:]–‘’]")
 	return re.MatchString(str)
 }
 

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -106,6 +106,12 @@ func TestCheckForSpecialCharacters(t *testing.T) {
 		c.So(actual, c.ShouldEqual, expected)
 	})
 
+	c.Convey("A string containing whitelisted special characters should return false", t, func() {
+		expected := false
+		actual := checkForSpecialCharacters("Test string –‘’")
+		c.So(actual, c.ShouldEqual, expected)
+	})
+
 	c.Convey("A string containing special characters should return true", t, func() {
 		expected := true
 		actual := checkForSpecialCharacters("Test 怎么开 string")

--- a/features/search.feature
+++ b/features/search.feature
@@ -57,3 +57,11 @@ Feature: Search endpoint should return data for requested search parameter
             """
             invalid URI prefix parameter
             """
+
+    Scenario: When Searching with whitelisted special characters I get the expected results
+        Given elasticsearch is healthy
+        And elasticsearch returns one item in search response
+        When I GET "/search?q=CPI–‘’"
+        Then the HTTP status code should be "200"
+        And the response header "Content-Type" should be "application/json;charset=utf-8"
+        And the response body is the same as the json in "./features/testdata/expected_single_search_result.json"


### PR DESCRIPTION
### What

This [adds](https://jira.ons.gov.uk/browse/DIS-1810) some non-ascii characters to search query validation.
**Characters**
- en hyphen/dash (windows ALT 0150) –
- opening single quote (windown ALT 0145) ‘
- closing single quote (windows ALT 0146) ’

### How to review

Run search api
http://localhost:23900/search?q=National+life+tables+–+life+expectancy
http://localhost:23900/search?q=UK+residents‘+visits+abroad

### Who can review

Anyone