### PR TITLE
Fix indentation for release type aggs

### DIFF
--- a/query/templates/releasecalendar/search.tmpl
+++ b/query/templates/releasecalendar/search.tmpl
@@ -137,68 +137,67 @@ ons
     "release_types": {
       "filters": {
         "other_bucket_key": "cancelled",
-          "filters": {
-            "upcoming": {
-              "bool": {
-                "must": [
-                  {
-                    "term": {
-                      "published": false
-                    }
-                  },
-                  {
-                    "term": {
-                      "cancelled": false
-                    }
-                  },
-                  {
-                    "range": {
-                      "release_date": {
-                        "gte": {{ .Now }}
-                      }
+        "filters": {
+          "upcoming": {
+            "bool": {
+              "must": [
+                {
+                  "term": {
+                    "published": false
+                  }
+                },
+                {
+                  "term": {
+                    "cancelled": false
+                  }
+                },
+                {
+                  "range": {
+                    "release_date": {
+                      "gte": {{ .Now }}
                     }
                   }
-                ]
-              }
-            },
-            "outdated": {
-              "bool": {
-                "must": [
-                  {
-                    "term": {
-                      "published": false
-                    }
-                  },
-                  {
-                    "term": {
-                      "cancelled": false
-                    }
-                  },
-                  {
-                    "range": {
-                      "release_date": {
-                        "lt": {{ .Now }}
-                      }
+                }
+              ]
+            }
+          },
+          "outdated": {
+            "bool": {
+              "must": [
+                {
+                  "term": {
+                    "published": false
+                  }
+                },
+                {
+                  "term": {
+                    "cancelled": false
+                  }
+                },
+                {
+                  "range": {
+                    "release_date": {
+                      "lt": {{ .Now }}
                     }
                   }
-                ]
-              }
-            },
-            "published": {
-              "bool": {
-                "must": [
-                  {
-                    "term": {
-                      "published": true
-                    }
-                  },
-                  {
-                    "term": {
-                      "cancelled": false
-                    }
+                }
+              ]
+            }
+          },
+          "published": {
+            "bool": {
+              "must": [
+                {
+                  "term": {
+                    "published": true
                   }
-                ]
-              }
+                },
+                {
+                  "term": {
+                    "cancelled": false
+                  }
+                }
+              ]
             }
           }
         }


### PR DESCRIPTION
### What

Some indentation went wrong as it was misaligned - I've added a new rule to the linter to compensate for this in future and run it across all files - this is the only one. 

### How to review

Check looks ok - it just outdents 'filters' and removes a closing brace later that was mistakenly in there. 

### Who can review

Not me. 